### PR TITLE
[FEAT] 시험 생성 및 특정 강의 시험 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/epari/exam/controller/ExamController.java
+++ b/src/main/java/com/example/epari/exam/controller/ExamController.java
@@ -1,6 +1,9 @@
 package com.example.epari.exam.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -8,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.epari.exam.dto.request.ExamRequestDto;
+import com.example.epari.exam.dto.response.ExamResponseDto;
 import com.example.epari.exam.service.ExamService;
 
 import lombok.RequiredArgsConstructor;
@@ -16,18 +20,26 @@ import lombok.RequiredArgsConstructor;
  * 시험 관련 HTTP 요청을 처리하는 Controller 클래스
  */
 @RestController
-@RequestMapping("/apu/lecture/{lectureId}/exams")
+@RequestMapping("/api/lectures/{lectureId}/exams")
 @RequiredArgsConstructor
 public class ExamController {
 
 	private final ExamService examService;
 
+	// 시험 생성
 	@PostMapping
 	public ResponseEntity<Long> createExam(
 			@PathVariable Long lectureId,
 			@RequestBody ExamRequestDto examRequestDto) {
 		Long examId = examService.createExam(lectureId, examRequestDto);
 		return ResponseEntity.ok(examId);
+	}
+
+	// 특정 강의에 해당하는 시험 정보 조회
+	@GetMapping
+	public ResponseEntity<List<ExamResponseDto>> getExams(@PathVariable Long lectureId) {
+		List<ExamResponseDto> exams = examService.getExamByLecture(lectureId);
+		return ResponseEntity.ok(exams);
 	}
 
 }

--- a/src/main/java/com/example/epari/exam/controller/ExamController.java
+++ b/src/main/java/com/example/epari/exam/controller/ExamController.java
@@ -1,0 +1,33 @@
+package com.example.epari.exam.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.epari.exam.dto.request.ExamRequestDto;
+import com.example.epari.exam.service.ExamService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 시험 관련 HTTP 요청을 처리하는 Controller 클래스
+ */
+@RestController
+@RequestMapping("/apu/lecture/{lectureId}/exams")
+@RequiredArgsConstructor
+public class ExamController {
+
+	private final ExamService examService;
+
+	@PostMapping
+	public ResponseEntity<Long> createExam(
+			@PathVariable Long lectureId,
+			@RequestBody ExamRequestDto examRequestDto) {
+		Long examId = examService.createExam(lectureId, examRequestDto);
+		return ResponseEntity.ok(examId);
+	}
+
+}

--- a/src/main/java/com/example/epari/exam/domain/Exam.java
+++ b/src/main/java/com/example/epari/exam/domain/Exam.java
@@ -15,7 +15,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -49,8 +48,7 @@ public class Exam extends BaseTimeEntity {
 	@Column(nullable = false)
 	private Integer totalScore;
 
-	@Lob
-	@Column(nullable = false)
+	@Column(length = 1000)
 	private String description;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/epari/exam/dto/request/ExamRequestDto.java
+++ b/src/main/java/com/example/epari/exam/dto/request/ExamRequestDto.java
@@ -1,0 +1,27 @@
+package com.example.epari.exam.dto.request;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 시험 생성 요청을 위한 DTO 클래스
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class ExamRequestDto {
+
+	private String title;
+
+	private LocalDateTime examDateTime;
+
+	private Integer duration;
+
+	private Integer totalScore;
+
+	private String description;
+
+}

--- a/src/main/java/com/example/epari/exam/dto/response/ExamResponseDto.java
+++ b/src/main/java/com/example/epari/exam/dto/response/ExamResponseDto.java
@@ -1,0 +1,43 @@
+package com.example.epari.exam.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.example.epari.exam.domain.Exam;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 시험 정보 조회 응답을 위한 DTO 클래스
+ */
+@Getter
+@Builder
+public class ExamResponseDto {
+
+	private Long id;
+
+	private String title;
+
+	private LocalDateTime examDateTime;
+
+	private Integer duration;
+
+	private Integer totalScore;
+
+	private String description;
+
+	private Long lecturerId;
+
+	public static ExamResponseDto fromExam(Exam exam) {
+		return ExamResponseDto.builder()
+				.id(exam.getId())
+				.title(exam.getTitle())
+				.examDateTime(exam.getExamDateTime())
+				.duration(exam.getDuration())
+				.totalScore(exam.getTotalScore())
+				.description(exam.getDescription())
+				.lecturerId(exam.getLecture().getId())
+				.build();
+	}
+
+}

--- a/src/main/java/com/example/epari/exam/repository/ExamRepository.java
+++ b/src/main/java/com/example/epari/exam/repository/ExamRepository.java
@@ -1,0 +1,13 @@
+package com.example.epari.exam.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.epari.exam.domain.Exam;
+
+/**
+ * 시험 정보에 대한 데이터베이스 접근을 담당하는 Repository 인터페이스
+ * - Spring Data JPA를 통해 기본적인 CRUD 연산을 제공
+ */
+public interface ExamRepository extends JpaRepository<Exam, Long> {
+
+}

--- a/src/main/java/com/example/epari/exam/repository/ExamRepository.java
+++ b/src/main/java/com/example/epari/exam/repository/ExamRepository.java
@@ -1,13 +1,17 @@
 package com.example.epari.exam.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.epari.exam.domain.Exam;
 
 /**
  * 시험 정보에 대한 데이터베이스 접근을 담당하는 Repository 인터페이스
- * - Spring Data JPA를 통해 기본적인 CRUD 연산을 제공
  */
 public interface ExamRepository extends JpaRepository<Exam, Long> {
+
+	// 특정 강의에 속한 모든 시험 조회
+	List<Exam> findByLectureId(Long lectureId);
 
 }

--- a/src/main/java/com/example/epari/exam/service/ExamService.java
+++ b/src/main/java/com/example/epari/exam/service/ExamService.java
@@ -1,0 +1,44 @@
+package com.example.epari.exam.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.epari.exam.domain.Exam;
+import com.example.epari.exam.dto.request.ExamRequestDto;
+import com.example.epari.exam.repository.ExamRepository;
+import com.example.epari.lecture.domain.Lecture;
+import com.example.epari.lecture.repository.LectureRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 시험 관련 비즈니스 로직을 처리하는 Service 클래스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExamService {
+
+	private final ExamRepository examRepository;
+
+	private final LectureRepository lectureRepository;
+
+	@Transactional
+	public Long createExam(Long lectureId, ExamRequestDto requestDto) {
+		// 강의 존재여부 확인
+		Lecture lecture = lectureRepository.findById(lectureId)
+				.orElseThrow(() -> new IllegalArgumentException("강의를 찾을 수 없습니다."));
+
+		Exam exam = Exam.builder()
+				.title(requestDto.getTitle())
+				.examDateTime(requestDto.getExamDateTime())
+				.duration(requestDto.getDuration())
+				.totalScore(requestDto.getTotalScore())
+				.description(requestDto.getDescription())
+				.lecture(lecture)
+				.build();
+
+		return examRepository.save(exam).getId();
+	}
+
+}

--- a/src/main/java/com/example/epari/exam/service/ExamService.java
+++ b/src/main/java/com/example/epari/exam/service/ExamService.java
@@ -1,10 +1,14 @@
 package com.example.epari.exam.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.epari.exam.domain.Exam;
 import com.example.epari.exam.dto.request.ExamRequestDto;
+import com.example.epari.exam.dto.response.ExamResponseDto;
 import com.example.epari.exam.repository.ExamRepository;
 import com.example.epari.lecture.domain.Lecture;
 import com.example.epari.lecture.repository.LectureRepository;
@@ -23,6 +27,7 @@ public class ExamService {
 
 	private final LectureRepository lectureRepository;
 
+	// 시험 생성
 	@Transactional
 	public Long createExam(Long lectureId, ExamRequestDto requestDto) {
 		// 강의 존재여부 확인
@@ -39,6 +44,20 @@ public class ExamService {
 				.build();
 
 		return examRepository.save(exam).getId();
+	}
+
+	// 특정 강의의 시험 조회
+	public List<ExamResponseDto> getExamByLecture(Long lectureId) {
+		// 강의 존재여부 확인
+		if (!lectureRepository.existsById(lectureId)) {
+			throw new IllegalArgumentException("강의를 찾을 수 없습니다. ID: " + lectureId);
+		}
+
+		// 시험 목록 조회 및 DTO 반환
+		return examRepository.findByLectureId(lectureId).stream()
+				.map(ExamResponseDto::fromExam)
+				.collect(Collectors.toList());
+
 	}
 
 }


### PR DESCRIPTION
## 관련 이슈
- Closes #15 

## 변경 사항
**1. 시험 생성 기능 구현**
  - ExamRequestDto, ExamRepository 클래스 생성
  - 시험 생성을 위한 ExamService `createExam` 메서드 구현
  - ExamController POST 엔드포인트 구현

2. 시험 목록 조회 기능 구현
  - ExamResponseDto 클래스 생성
  - 특정 강의의 모든 시험 목록을 조회하는 ExamRepository `findByLectureId` 메서드 추가
  - 조회를 위한 ExamService `getExamsByLecture` 메서드 구현
  - ExamController GET 엔드포인트 구현

## 스크린샷
|기능|스크린샷|
|---|:---:|
|시험 생성|<img src="https://github.com/user-attachments/assets/9af43e72-c241-4fff-984e-3aa8d2b6a047" width="80%">|
|특정 강의의 모든 시험목록 조회|<img src="https://github.com/user-attachments/assets/60a772c0-8451-4f75-b1df-d312c6ce039b" width="80%">|

## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 추후 업무
- [ ] 시험 상세 조회 기능 구현
- [ ] 시험 수정 기능 구현
- [ ] 시험 삭제 기능 구현
- [ ] 시험 문제 관리 기능 구현