### PR TITLE
[FEAT] 출석 상태 변경 엔드포인트 구현

### DIFF
--- a/src/main/java/com/example/epari/assignment/dto/assignment/AssignmentResponseDto.java
+++ b/src/main/java/com/example/epari/assignment/dto/assignment/AssignmentResponseDto.java
@@ -25,8 +25,6 @@ public class AssignmentResponseDto {
 
 	private LocalDateTime deadline; // 마감기한
 
-	private String feedback;        // 전체 피드백
-
 	private List<AssignmentFileResponseDto> files; // 첨부파일 목록
 
 	public AssignmentResponseDto(Assignment assignment) {
@@ -34,7 +32,6 @@ public class AssignmentResponseDto {
 		this.title = assignment.getTitle();
 		this.description = assignment.getDescription();
 		this.deadline = assignment.getDeadline();
-		this.feedback = assignment.getFeedback();
 		this.files = assignment.getFiles().stream().map(AssignmentFileResponseDto::new).collect(Collectors.toList());
 	}
 

--- a/src/main/java/com/example/epari/lecture/controller/AttendanceController.java
+++ b/src/main/java/com/example/epari/lecture/controller/AttendanceController.java
@@ -6,15 +6,19 @@ import java.util.List;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.epari.global.annotation.CurrentUserEmail;
 import com.example.epari.lecture.dto.attendance.AttendanceResponseDto;
+import com.example.epari.lecture.dto.attendance.AttendanceUpdateDto;
 import com.example.epari.lecture.service.AttendanceService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -44,6 +48,21 @@ public class AttendanceController {
 		);
 
 		return ResponseEntity.ok(responses);
+	}
+
+	/**
+	 * 특정 날짜의 학생들 출석 상태를 일괄 수정
+	 */
+	@PatchMapping
+	public ResponseEntity<Void> updateAttendances(
+			@PathVariable Long lectureId,
+			@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+			@RequestBody @Valid List<AttendanceUpdateDto> request,
+			@CurrentUserEmail String email
+	) {
+		attendanceService.updateAttendances(lectureId, email, date, request);
+
+		return ResponseEntity.ok().build();
 	}
 
 }

--- a/src/main/java/com/example/epari/lecture/domain/Attendance.java
+++ b/src/main/java/com/example/epari/lecture/domain/Attendance.java
@@ -43,8 +43,6 @@ public class Attendance extends BaseTimeEntity {
 	@Column(nullable = false)
 	private AttendanceStatus status;
 
-	private String note; // 비고(사유 등)
-
 	@Builder
 	private Attendance(LectureStudent lectureStudent, LocalDate date) {
 		this.lectureStudent = lectureStudent;

--- a/src/main/java/com/example/epari/lecture/domain/Attendance.java
+++ b/src/main/java/com/example/epari/lecture/domain/Attendance.java
@@ -52,9 +52,8 @@ public class Attendance extends BaseTimeEntity {
 		this.status = AttendanceStatus.ABSENT;
 	}
 
-	public void updateStatus(AttendanceStatus status, String note) {
+	public void updateStatus(AttendanceStatus status) {
 		this.status = status;
-		this.note = note;
 	}
 
 }

--- a/src/main/java/com/example/epari/lecture/dto/attendance/AttendanceResponseDto.java
+++ b/src/main/java/com/example/epari/lecture/dto/attendance/AttendanceResponseDto.java
@@ -1,6 +1,5 @@
 package com.example.epari.lecture.dto.attendance;
 
-import com.example.epari.global.common.enums.AttendanceStatus;
 import com.example.epari.lecture.domain.Attendance;
 
 import lombok.Builder;
@@ -16,10 +15,10 @@ public class AttendanceResponseDto {
 
 	private final String name;
 
-	private final AttendanceStatus status;
+	private final String status;
 
 	@Builder
-	private AttendanceResponseDto(Long studentId, String name, AttendanceStatus status) {
+	private AttendanceResponseDto(Long studentId, String name, String status) {
 		this.studentId = studentId;
 		this.name = name;
 		this.status = status;
@@ -29,7 +28,7 @@ public class AttendanceResponseDto {
 		return AttendanceResponseDto.builder()
 				.studentId(attendance.getLectureStudent().getStudent().getId())
 				.name(attendance.getLectureStudent().getStudent().getName())
-				.status(attendance.getStatus())
+				.status(attendance.getStatus().getDescription())
 				.build();
 	}
 

--- a/src/main/java/com/example/epari/lecture/dto/attendance/AttendanceUpdateDto.java
+++ b/src/main/java/com/example/epari/lecture/dto/attendance/AttendanceUpdateDto.java
@@ -7,6 +7,9 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * 출석 상태 변경 요청 데이터를 담는 DTO 클래스
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/example/epari/lecture/dto/attendance/AttendanceUpdateDto.java
+++ b/src/main/java/com/example/epari/lecture/dto/attendance/AttendanceUpdateDto.java
@@ -1,0 +1,21 @@
+package com.example.epari.lecture.dto.attendance;
+
+import com.example.epari.global.common.enums.AttendanceStatus;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AttendanceUpdateDto {
+
+	@NotNull(message = "학생 ID는 필수입니다.")
+	private Long studentId;
+
+	@NotNull(message = "출석 상태는 필수입니다.")
+	private AttendanceStatus status;
+
+}

--- a/src/main/java/com/example/epari/lecture/repository/AttendanceRepository.java
+++ b/src/main/java/com/example/epari/lecture/repository/AttendanceRepository.java
@@ -30,4 +30,22 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
 			@Param("date") LocalDate date
 	);
 
+	/**
+	 * 특정 강의, 날짜의 특정 학생들의 출석 데이터 조회
+	 */
+	@Query("""
+			SELECT a
+			FROM Attendance a
+			JOIN FETCH a.lectureStudent ls
+			JOIN FETCH ls.student
+			WHERE ls.lecture.id = :lectureId
+			AND a.date = :date
+			AND a.lectureStudent.id IN :studentIds
+			""")
+	List<Attendance> findByLectureIdAndDateAndStudentIds(
+			@Param("lectureId") Long lectureId,
+			@Param("date") LocalDate date,
+			@Param("studentIds") List<Long> studentIds
+	);
+
 }

--- a/src/main/java/com/example/epari/lecture/repository/AttendanceRepository.java
+++ b/src/main/java/com/example/epari/lecture/repository/AttendanceRepository.java
@@ -37,10 +37,10 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
 			SELECT a
 			FROM Attendance a
 			JOIN FETCH a.lectureStudent ls
-			JOIN FETCH ls.student
+			JOIN FETCH ls.student s
 			WHERE ls.lecture.id = :lectureId
 			AND a.date = :date
-			AND a.lectureStudent.id IN :studentIds
+			AND s.id IN :studentIds
 			""")
 	List<Attendance> findByLectureIdAndDateAndStudentIds(
 			@Param("lectureId") Long lectureId,

--- a/src/main/java/com/example/epari/lecture/service/AttendanceService.java
+++ b/src/main/java/com/example/epari/lecture/service/AttendanceService.java
@@ -2,6 +2,8 @@ package com.example.epari.lecture.service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.example.epari.lecture.domain.Attendance;
 import com.example.epari.lecture.domain.LectureStudent;
 import com.example.epari.lecture.dto.attendance.AttendanceResponseDto;
+import com.example.epari.lecture.dto.attendance.AttendanceUpdateDto;
 import com.example.epari.lecture.repository.AttendanceRepository;
 import com.example.epari.lecture.repository.LectureRepository;
 import com.example.epari.lecture.repository.LectureStudentRepository;
@@ -46,6 +49,55 @@ public class AttendanceService {
 		return attendances.stream()
 				.map(AttendanceResponseDto::from)
 				.toList();
+	}
+
+	/**
+	 * 특정 강의, 날짜의 학생 출석 상태를 변경
+	 */
+	@Transactional
+	public void updateAttendances(
+			Long lectureId,
+			String instructorEmail,
+			LocalDate date,
+			List<AttendanceUpdateDto> updates
+	) {
+		// 강사 권한 검증
+		validateInstructorAccess(lectureId, instructorEmail);
+
+		// 수정할 학생 ID 목록 추출
+		List<Long> studentIds = updates.stream()
+				.map(AttendanceUpdateDto::getStudentId)
+				.toList();
+
+		// 수정할 출석 데이터만 조회
+		List<Attendance> attendances = attendanceRepository.findByLectureIdAndDateAndStudentIds(
+				lectureId,
+				date,
+				studentIds
+		);
+
+		// 출석 데이터가 하나라도 없다면 해당 날짜 출석부가 없는 것
+		if (attendances.isEmpty()) {
+			throw new IllegalArgumentException("해당 날짜의 출석 데이터가 존재하지 않습니다.");
+		}
+
+		// 조회된 데이터 수와 요청된 수가 다르다면 잘못된 요청
+		if (attendances.size() != updates.size()) {
+			throw new IllegalArgumentException("일부 학생의 출석 데이터를 찾을 수 없습니다.");
+		}
+
+		// studentId를 key로 하는 Map으로 변환하여 빠른 조회 가능하도록 함
+		Map<Long, Attendance> attendanceMap = attendances.stream()
+				.collect(Collectors.toMap(
+						attendance -> attendance.getLectureStudent().getStudent().getId(),
+						attendance -> attendance
+				));
+
+		// 업데이트 수행
+		updates.forEach(update -> {
+			Attendance attendance = attendanceMap.get(update.getStudentId());
+			attendance.updateStatus(update.getStatus());
+		});
 	}
 
 	/**


### PR DESCRIPTION
## 관련 이슈
- Closes #31 

## 변경 사항
1. AttendanceResponseDto 수정
    - status 필드 타입을 AttendanceStatus enum에서 String으로 변경
    - enum 대신 description 필드를 반환하도록 수정

2. 출석 상태 변경 기능 구현
    - 출석 상태 변경을 위한 요청 DTO 추가
    - 특정 학생들의 출석 데이터를 조회하는 쿼리 메서드 구현
    - 특정 학생들의 출석 상태를 변경하는 서비스 메서드 구현
    - 출석 상태 변경 엔드포인트 추가

3. 버그 수정 및 코드 정리
    - LectureStudent의 id가 아닌 학생 id 기반으로 조회하도록 JPQL 수정
    - 불필요한 비고 필드 제거
    - feedback 관련 미사용 코드 정리

## 스크린샷
|기능|스크린샷|
|---|---|
|출석 상태 변경|![image](https://github.com/user-attachments/assets/04dde210-2167-4621-a5ea-db5fc0fa438a)|

## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- AttendanceStatus enum 대신 description 문자열을 직접 반환하도록 변경했습니다.
- 학생 ID 기반으로 출석 데이터를 조회하도록 쿼리를 수정했습니다.
- 불필요한 비고 필드와 피드백 관련 코드를 제거하여 코드를 정리했습니다.

## 추후 업무
- [ ] 코드 리팩토링