### PR TITLE
[FEAT] 역할 별 모든 시험 조회 기능 구현 및 코드 리팩토링

### DIFF
--- a/src/main/java/com/example/epari/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/epari/course/repository/CourseRepository.java
@@ -17,16 +17,16 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 	/**
 	 * 학생 id를 받아 강의 id 와 학생 id 일치로 조회 강의 조회
 	 */
-	@Query("SELECT l FROM Course l "
-		   + "INNER JOIN CourseStudent ls ON l.id = ls.course.id "
-		   + "WHERE ls.student.id = :studentId")
+	@Query("SELECT c FROM Course c "
+			+ "INNER JOIN CourseStudent cs ON c.id = cs.course.id "
+			+ "WHERE cs.student.id = :studentId")
 	List<Course> findAllByStudentId(@Param("studentId") Long studentId);
 
 	/**
 	 * 강사 id를 받아 강의 테이블에서 일치하는지 확인 강의 조회
 	 */
-	@Query("SELECT l FROM Course l "
-		   + "WHERE l.instructor.id = :instructorId")
+	@Query("SELECT c FROM Course c "
+			+ "WHERE c.instructor.id = :instructorId")
 	List<Course> findAllByInstructorId(@Param("instructorId") Long instructorId);
 
 	/**
@@ -35,11 +35,29 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 	@Query("""
 			SELECT EXISTS (
 			    SELECT 1
-			    FROM Course l
-			    WHERE l.id = :courseId
-			    AND l.instructor.email = :instructorEmail
+			    FROM Course c
+			    WHERE c.id = :courseId
+			    AND c.instructor.email = :instructorEmail
 			)
 			""")
-	boolean existsByCourseIdAndInstructorEmail(Long courseId, String instructorEmail);
+	boolean existsByCourseIdAndInstructorEmail(
+			@Param("courseId") Long courseId,
+			@Param("instructorEmail") String instructorEmail);
+
+	/**
+	 * 주어진 강의 ID와 학생 이메일로 해당 강의를 수강중인 학생인지 확인합니다.
+	 */
+	@Query("""
+			SELECT EXISTS (
+			    SELECT 1
+			    FROM Course c
+			    JOIN CourseStudent cs ON c.id = cs.course.id
+			    WHERE c.id = :courseId
+			    AND cs.student.email = :studentEmail
+			)
+			""")
+	boolean existsByCourseIdAndStudentEmail(
+			@Param("courseId") Long courseId,
+			@Param("studentEmail") String studentEmail);
 
 }

--- a/src/main/java/com/example/epari/exam/controller/ExamController.java
+++ b/src/main/java/com/example/epari/exam/controller/ExamController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.epari.exam.dto.request.ExamRequestDto;
 import com.example.epari.exam.dto.response.ExamResponseDto;
 import com.example.epari.exam.service.ExamService;
+import com.example.epari.exam.service.InstructorExamService;
+import com.example.epari.global.annotation.CurrentUserEmail;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,12 +30,15 @@ public class ExamController {
 
 	private final ExamService examService;
 
+	private final InstructorExamService instructorExamService;
+
 	// 시험 생성
 	@PostMapping
 	public ResponseEntity<Long> createExam(
 			@PathVariable Long courseId,
-			@RequestBody ExamRequestDto examRequestDto) {
-		Long examId = examService.createExam(courseId, examRequestDto);
+			@RequestBody ExamRequestDto examRequestDto,
+			@CurrentUserEmail String instructorEmail) {
+		Long examId = instructorExamService.createExam(courseId, examRequestDto, instructorEmail);
 		return ResponseEntity.ok(examId);
 	}
 
@@ -58,8 +63,9 @@ public class ExamController {
 	public ResponseEntity<ExamResponseDto> updateExam(
 			@PathVariable Long courseId,
 			@PathVariable("examId") Long id,
-			@RequestBody ExamRequestDto examRequestDto) {
-		ExamResponseDto updateExam = examService.updateExam(courseId, id, examRequestDto);
+			@RequestBody ExamRequestDto examRequestDto,
+			@CurrentUserEmail String instructorEmail) {
+		ExamResponseDto updateExam = instructorExamService.updateExam(courseId, id, examRequestDto, instructorEmail);
 		return ResponseEntity.ok(updateExam);
 	}
 
@@ -67,8 +73,9 @@ public class ExamController {
 	@DeleteMapping("/{examId}")
 	public ResponseEntity<Void> deleteExam(
 			@PathVariable Long courseId,
-			@PathVariable("examId") Long id) {
-		examService.deleteExam(courseId, id);
+			@PathVariable("examId") Long id,
+			@CurrentUserEmail String instructorEmail) {
+		instructorExamService.deleteExam(courseId, id, instructorEmail);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/com/example/epari/exam/controller/InstructorExamController.java
+++ b/src/main/java/com/example/epari/exam/controller/InstructorExamController.java
@@ -1,0 +1,32 @@
+package com.example.epari.exam.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.epari.exam.dto.response.ExamResponseDto;
+import com.example.epari.exam.service.ExamService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 마이페이지 시험 관련 HTTP 요청을 처리하는 Controller 클래스
+ */
+@RestController
+@RequestMapping("/api/instructor/exams")
+@RequiredArgsConstructor
+public class InstructorExamController {
+
+	private final ExamService examService;
+
+	// 강사가 담당하는 강의의 모든 시험 조회
+	@GetMapping
+	public ResponseEntity<List<ExamResponseDto>> getExamsByInstructor() {
+		List<ExamResponseDto> exams = examService.getExamByInstructor();
+		return ResponseEntity.ok(exams);
+	}
+
+}

--- a/src/main/java/com/example/epari/exam/controller/InstructorExamController.java
+++ b/src/main/java/com/example/epari/exam/controller/InstructorExamController.java
@@ -8,24 +8,25 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.epari.exam.dto.response.ExamResponseDto;
-import com.example.epari.exam.service.ExamService;
+import com.example.epari.exam.service.InstructorExamService;
+import com.example.epari.global.annotation.CurrentUserEmail;
 
 import lombok.RequiredArgsConstructor;
 
 /**
- * 마이페이지 시험 관련 HTTP 요청을 처리하는 Controller 클래스
+ * 강사의 시험 관련 HTTP 요청을 처리하는 Controller 클래스
  */
 @RestController
 @RequestMapping("/api/instructor/exams")
 @RequiredArgsConstructor
 public class InstructorExamController {
 
-	private final ExamService examService;
+	private final InstructorExamService instructorExamService;
 
 	// 강사가 담당하는 강의의 모든 시험 조회
 	@GetMapping
-	public ResponseEntity<List<ExamResponseDto>> getExamsByInstructor() {
-		List<ExamResponseDto> exams = examService.getExamByInstructor();
+	public ResponseEntity<List<ExamResponseDto>> getExamsByInstructor(@CurrentUserEmail String email) {
+		List<ExamResponseDto> exams = instructorExamService.getExams(email);
 		return ResponseEntity.ok(exams);
 	}
 

--- a/src/main/java/com/example/epari/exam/controller/StudentExamController.java
+++ b/src/main/java/com/example/epari/exam/controller/StudentExamController.java
@@ -1,0 +1,32 @@
+package com.example.epari.exam.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.epari.exam.dto.response.ExamResponseDto;
+import com.example.epari.exam.service.ExamService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 마이페이지 시험 관련 HTTP 요청을 처리하는 Controller 클래스
+ */
+@RestController
+@RequestMapping("/api/student/exams")
+@RequiredArgsConstructor
+public class StudentExamController {
+
+	private final ExamService examService;
+
+	// 학생이 수강중인 강의의 모든 시험 조회
+	@GetMapping
+	public ResponseEntity<List<ExamResponseDto>> getExamsByStudent() {
+		List<ExamResponseDto> exams = examService.getExamByStudent();
+		return ResponseEntity.ok(exams);
+	}
+
+}

--- a/src/main/java/com/example/epari/exam/controller/StudentExamController.java
+++ b/src/main/java/com/example/epari/exam/controller/StudentExamController.java
@@ -8,24 +8,25 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.epari.exam.dto.response.ExamResponseDto;
-import com.example.epari.exam.service.ExamService;
+import com.example.epari.exam.service.StudentExamService;
+import com.example.epari.global.annotation.CurrentUserEmail;
 
 import lombok.RequiredArgsConstructor;
 
 /**
- * 마이페이지 시험 관련 HTTP 요청을 처리하는 Controller 클래스
+ * 학생 시험 관련 HTTP 요청을 처리하는 Controller 클래스
  */
 @RestController
 @RequestMapping("/api/student/exams")
 @RequiredArgsConstructor
 public class StudentExamController {
 
-	private final ExamService examService;
+	private final StudentExamService studentExamService;
 
 	// 학생이 수강중인 강의의 모든 시험 조회
 	@GetMapping
-	public ResponseEntity<List<ExamResponseDto>> getExamsByStudent() {
-		List<ExamResponseDto> exams = examService.getExamByStudent();
+	public ResponseEntity<List<ExamResponseDto>> getExamsByStudent(@CurrentUserEmail String email) {
+		List<ExamResponseDto> exams = studentExamService.getExams(email);
 		return ResponseEntity.ok(exams);
 	}
 

--- a/src/main/java/com/example/epari/exam/dto/response/ExamResponseDto.java
+++ b/src/main/java/com/example/epari/exam/dto/response/ExamResponseDto.java
@@ -26,7 +26,7 @@ public class ExamResponseDto {
 
 	private String description;
 
-	private Long courserId;
+	private Long courseId;
 
 	public static ExamResponseDto fromExam(Exam exam) {
 		return ExamResponseDto.builder()
@@ -36,7 +36,7 @@ public class ExamResponseDto {
 				.duration(exam.getDuration())
 				.totalScore(exam.getTotalScore())
 				.description(exam.getDescription())
-				.courserId(exam.getCourse().getId())
+				.courseId(exam.getCourse().getId())
 				.build();
 	}
 

--- a/src/main/java/com/example/epari/exam/repository/ExamRepository.java
+++ b/src/main/java/com/example/epari/exam/repository/ExamRepository.java
@@ -26,14 +26,20 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
 	 * 2. 강사
 	 */
 	// 강사가 담당하는 강의의 모든 시험 조회
-	@Query("SELECT e FROM Exam e JOIN FETCH e.course c JOIN c.instructor i WHERE i.email = :email")
-	List<Exam> findByInstructorEmail(String email);
+	@Query("SELECT e FROM Exam e "
+			+ "JOIN FETCH e.course c "
+			+ "JOIN c.instructor i "
+			+ "WHERE i.email = :instructorEmail")
+	List<Exam> findByInstructorEmail(String instructorEmail);
 
 	/**
 	 * 3. 학생
 	 */
 	// 학생이 수강중인 강의의 모든 시험 조회
-	@Query("SELECT e FROM Exam e JOIN FETCH e.course c JOIN CourseStudent cs WHERE cs.student.email = :email AND cs.course = c")
-	List<Exam> findByStudentEmail(String email);
+	@Query("SELECT e FROM Exam e "
+			+ "JOIN FETCH e.course c "
+			+ "JOIN CourseStudent cs ON cs.course = c "
+			+ "WHERE cs.student.email = :studentEmail")
+	List<Exam> findByStudentEmail(String studentEmail);
 
 }

--- a/src/main/java/com/example/epari/exam/repository/ExamRepository.java
+++ b/src/main/java/com/example/epari/exam/repository/ExamRepository.java
@@ -20,20 +20,20 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
 	List<Exam> findByCourseId(Long courseId);
 
 	// 특정 강의에 속한 시험 상세 조회
-	Optional<Exam> findByCourseIdAndId(Long courseId, Long Id);
+	Optional<Exam> findByCourseIdAndId(Long courseId, Long id);
 
 	/**
 	 * 2. 강사
 	 */
 	// 강사가 담당하는 강의의 모든 시험 조회
-	@Query("SELECT e FROM Exam e JOIN e.course c WHERE c.instructor.id = :instructorId")
-	List<Exam> findByInstructorId(Long instructorId);
+	@Query("SELECT e FROM Exam e JOIN FETCH e.course c JOIN c.instructor i WHERE i.email = :email")
+	List<Exam> findByInstructorEmail(String email);
 
 	/**
 	 * 3. 학생
 	 */
 	// 학생이 수강중인 강의의 모든 시험 조회
-	@Query("SELECT e FROM Exam e JOIN e.course c JOIN CourseStudent cs WHERE cs.student.id = :student.Id AND cs.course = c")
-	List<Exam> findByStudentId(Long studentId);
+	@Query("SELECT e FROM Exam e JOIN FETCH e.course c JOIN CourseStudent cs WHERE cs.student.email = :email AND cs.course = c")
+	List<Exam> findByStudentEmail(String email);
 
 }

--- a/src/main/java/com/example/epari/exam/repository/ExamRepository.java
+++ b/src/main/java/com/example/epari/exam/repository/ExamRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.example.epari.exam.domain.Exam;
 
@@ -12,10 +13,27 @@ import com.example.epari.exam.domain.Exam;
  */
 public interface ExamRepository extends JpaRepository<Exam, Long> {
 
+	/**
+	 * 1. 강의
+	 */
 	// 특정 강의에 속한 모든 시험 조회
 	List<Exam> findByCourseId(Long courseId);
 
 	// 특정 강의에 속한 시험 상세 조회
 	Optional<Exam> findByCourseIdAndId(Long courseId, Long Id);
+
+	/**
+	 * 2. 강사
+	 */
+	// 강사가 담당하는 강의의 모든 시험 조회
+	@Query("SELECT e FROM Exam e JOIN e.course c WHERE c.instructor.id = :instructorId")
+	List<Exam> findByInstructorId(Long instructorId);
+
+	/**
+	 * 3. 학생
+	 */
+	// 학생이 수강중인 강의의 모든 시험 조회
+	@Query("SELECT e FROM Exam e JOIN e.course c JOIN CourseStudent cs WHERE cs.student.id = :student.Id AND cs.course = c")
+	List<Exam> findByStudentId(Long studentId);
 
 }

--- a/src/main/java/com/example/epari/exam/service/ExamService.java
+++ b/src/main/java/com/example/epari/exam/service/ExamService.java
@@ -6,10 +6,8 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.example.epari.course.domain.Course;
 import com.example.epari.course.repository.CourseRepository;
 import com.example.epari.exam.domain.Exam;
-import com.example.epari.exam.dto.request.ExamRequestDto;
 import com.example.epari.exam.dto.response.ExamResponseDto;
 import com.example.epari.exam.repository.ExamRepository;
 
@@ -26,24 +24,6 @@ public class ExamService {
 	private final ExamRepository examRepository;
 
 	private final CourseRepository courseRepository;
-
-	// 시험 생성
-	public Long createExam(Long courseId, ExamRequestDto requestDto) {
-		// 강의 존재여부 확인
-		Course course = courseRepository.findById(courseId)
-				.orElseThrow(() -> new IllegalArgumentException("강의를 찾을 수 없습니다."));
-
-		Exam exam = Exam.builder()
-				.title(requestDto.getTitle())
-				.examDateTime(requestDto.getExamDateTime())
-				.duration(requestDto.getDuration())
-				.totalScore(requestDto.getTotalScore())
-				.description(requestDto.getDescription())
-				.course(course)
-				.build();
-
-		return examRepository.save(exam).getId();
-	}
 
 	// 특정 강의의 시험 조회
 	@Transactional(readOnly = true)
@@ -71,38 +51,6 @@ public class ExamService {
 				.orElseThrow(() -> new IllegalArgumentException("시험을 찾을 수 없습니다." + id));
 
 		return ExamResponseDto.fromExam(exam);
-	}
-
-	// 특정 강의에 속한 시험 수정
-	public ExamResponseDto updateExam(Long courseId, Long id, ExamRequestDto requestDto) {
-		if (!courseRepository.existsById(courseId)) {
-			throw new IllegalArgumentException("강의를 찾을 수 없습니다. ID: " + courseId);
-		}
-
-		Exam exam = examRepository.findByCourseIdAndId(courseId, id)
-				.orElseThrow(() -> new IllegalArgumentException("시험을 찾을 수 없습니다. ID:" + id));
-
-		exam.updateExam(
-				requestDto.getTitle(),
-				requestDto.getExamDateTime(),
-				requestDto.getDuration(),
-				requestDto.getTotalScore(),
-				requestDto.getDescription()
-		);
-
-		return ExamResponseDto.fromExam(exam);
-	}
-
-	// 특정 강의에 속한 시험 삭제
-	public void deleteExam(Long courseId, Long id) {
-		if (!courseRepository.existsById(courseId)) {
-			throw new IllegalArgumentException("강의를 찾을 수 없습니다. ID: " + courseId);
-		}
-
-		Exam exam = examRepository.findByCourseIdAndId(courseId, id)
-				.orElseThrow(() -> new IllegalArgumentException("시험을 찾을 수 없습니다. ID:" + id));
-
-		examRepository.delete(exam);
 	}
 
 }

--- a/src/main/java/com/example/epari/exam/service/InstructorExamService.java
+++ b/src/main/java/com/example/epari/exam/service/InstructorExamService.java
@@ -13,7 +13,7 @@ import com.example.epari.exam.repository.ExamRepository;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 강사 시험 조회 관련 비즈니스 로직을 처리하는 Service 클래스
+ * 강사의 시험 조회 관련 비즈니스 로직을 처리하는 Service 클래스
  */
 @Service
 @RequiredArgsConstructor
@@ -22,8 +22,8 @@ public class InstructorExamService {
 
 	private final ExamRepository examRepository;
 
-	public List<ExamResponseDto> getExams(Long instructorId) {
-		List<Exam> exams = examRepository.findByInstructorId(instructorId);
+	public List<ExamResponseDto> getExams(String email) {
+		List<Exam> exams = examRepository.findByInstructorEmail(email);
 		return exams.stream()
 				.map(ExamResponseDto::fromExam)
 				.collect(Collectors.toList());

--- a/src/main/java/com/example/epari/exam/service/InstructorExamService.java
+++ b/src/main/java/com/example/epari/exam/service/InstructorExamService.java
@@ -6,9 +6,13 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.epari.course.domain.Course;
+import com.example.epari.course.repository.CourseRepository;
 import com.example.epari.exam.domain.Exam;
+import com.example.epari.exam.dto.request.ExamRequestDto;
 import com.example.epari.exam.dto.response.ExamResponseDto;
 import com.example.epari.exam.repository.ExamRepository;
+import com.example.epari.global.validator.CourseAccessValidator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,11 +26,75 @@ public class InstructorExamService {
 
 	private final ExamRepository examRepository;
 
+	private final CourseRepository courseRepository;
+
+	private final CourseAccessValidator courseAccessValidator;
+
+	@Transactional(readOnly = true)
 	public List<ExamResponseDto> getExams(String email) {
 		List<Exam> exams = examRepository.findByInstructorEmail(email);
 		return exams.stream()
 				.map(ExamResponseDto::fromExam)
 				.collect(Collectors.toList());
+	}
+
+	// 특정 강의에 시험 생성
+	public Long createExam(Long courseId, ExamRequestDto requestDto, String instructorEmail) {
+
+		courseAccessValidator.validateInstructorAccess(courseId, instructorEmail);
+
+		// 강의 존재여부 확인
+		Course course = courseRepository.findById(courseId)
+				.orElseThrow(() -> new IllegalArgumentException("강의를 찾을 수 없습니다."));
+
+		Exam exam = Exam.builder()
+				.title(requestDto.getTitle())
+				.examDateTime(requestDto.getExamDateTime())
+				.duration(requestDto.getDuration())
+				.totalScore(requestDto.getTotalScore())
+				.description(requestDto.getDescription())
+				.course(course)
+				.build();
+
+		return examRepository.save(exam).getId();
+	}
+
+	// 특정 강의에 속한 시험 수정
+	public ExamResponseDto updateExam(Long courseId, Long id, ExamRequestDto requestDto, String instructorEmail) {
+
+		courseAccessValidator.validateInstructorAccess(courseId, instructorEmail);
+
+		if (!courseRepository.existsById(courseId)) {
+			throw new IllegalArgumentException("강의를 찾을 수 없습니다. ID: " + courseId);
+		}
+
+		Exam exam = examRepository.findByCourseIdAndId(courseId, id)
+				.orElseThrow(() -> new IllegalArgumentException("시험을 찾을 수 없습니다. ID:" + id));
+
+		exam.updateExam(
+				requestDto.getTitle(),
+				requestDto.getExamDateTime(),
+				requestDto.getDuration(),
+				requestDto.getTotalScore(),
+				requestDto.getDescription()
+		);
+
+		return ExamResponseDto.fromExam(exam);
+	}
+
+	// 특정 강의에 속한 시험 삭제
+	public void deleteExam(Long courseId, Long id, String instructorEmail) {
+
+		courseAccessValidator.validateInstructorAccess(courseId, instructorEmail);
+
+		if (!courseRepository.existsById(courseId)) {
+			throw new IllegalArgumentException("강의를 찾을 수 없습니다. ID: " + courseId);
+		}
+
+		Exam exam = examRepository.findByCourseIdAndId(courseId, id)
+				.orElseThrow(() -> new IllegalArgumentException("시험을 찾을 수 없습니다. ID:" + id));
+
+		examRepository.delete(exam);
 	}
 
 }

--- a/src/main/java/com/example/epari/exam/service/InstructorExamService.java
+++ b/src/main/java/com/example/epari/exam/service/InstructorExamService.java
@@ -1,0 +1,32 @@
+package com.example.epari.exam.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.epari.exam.domain.Exam;
+import com.example.epari.exam.dto.response.ExamResponseDto;
+import com.example.epari.exam.repository.ExamRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 강사 시험 조회 관련 비즈니스 로직을 처리하는 Service 클래스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class InstructorExamService {
+
+	private final ExamRepository examRepository;
+
+	public List<ExamResponseDto> getExams(Long instructorId) {
+		List<Exam> exams = examRepository.findByInstructorId(instructorId);
+		return exams.stream()
+				.map(ExamResponseDto::fromExam)
+				.collect(Collectors.toList());
+	}
+
+}

--- a/src/main/java/com/example/epari/exam/service/StudentExamService.java
+++ b/src/main/java/com/example/epari/exam/service/StudentExamService.java
@@ -1,0 +1,32 @@
+package com.example.epari.exam.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.epari.exam.domain.Exam;
+import com.example.epari.exam.dto.response.ExamResponseDto;
+import com.example.epari.exam.repository.ExamRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 학생 시험 조회 관련 비즈니스 로직을 처리하는 Service 클래스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StudentExamService {
+
+	private final ExamRepository examRepository;
+
+	public List<ExamResponseDto> getExams(Long studentId) {
+		List<Exam> exams = examRepository.findByStudentId(studentId);
+		return exams.stream()
+				.map(ExamResponseDto::fromExam)
+				.collect(Collectors.toList());
+	}
+
+}

--- a/src/main/java/com/example/epari/exam/service/StudentExamService.java
+++ b/src/main/java/com/example/epari/exam/service/StudentExamService.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
  */
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class StudentExamService {
 
 	private final ExamRepository examRepository;

--- a/src/main/java/com/example/epari/exam/service/StudentExamService.java
+++ b/src/main/java/com/example/epari/exam/service/StudentExamService.java
@@ -13,7 +13,7 @@ import com.example.epari.exam.repository.ExamRepository;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 학생 시험 조회 관련 비즈니스 로직을 처리하는 Service 클래스
+ * 학생의 시험 조회 관련 비즈니스 로직을 처리하는 Service 클래스
  */
 @Service
 @RequiredArgsConstructor
@@ -22,8 +22,8 @@ public class StudentExamService {
 
 	private final ExamRepository examRepository;
 
-	public List<ExamResponseDto> getExams(Long studentId) {
-		List<Exam> exams = examRepository.findByStudentId(studentId);
+	public List<ExamResponseDto> getExams(String email) {
+		List<Exam> exams = examRepository.findByStudentEmail(email);
 		return exams.stream()
 				.map(ExamResponseDto::fromExam)
 				.collect(Collectors.toList());

--- a/src/main/java/com/example/epari/global/validator/CourseAccessValidator.java
+++ b/src/main/java/com/example/epari/global/validator/CourseAccessValidator.java
@@ -1,0 +1,32 @@
+package com.example.epari.global.validator;
+
+import org.springframework.stereotype.Component;
+
+import com.example.epari.course.repository.CourseRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 접근 권한을 검증하는 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class CourseAccessValidator {
+
+	private final CourseRepository courseRepository;
+
+	// 강사의 강의 접근권한 검증
+	public void validateInstructorAccess(Long courseId, String instructorEmail) {
+		if (!courseRepository.existsByCourseIdAndInstructorEmail(courseId, instructorEmail)) {
+			throw new IllegalArgumentException("해당 강의에 대한 접근 권한이 없습니다.");
+		}
+	}
+
+	// 학생의 강의 접근권한 검증
+	public void validateStudentAccess(Long courseId, String studentEmail) {
+		if (!courseRepository.existsByCourseIdAndStudentEmail(courseId, studentEmail)) {
+			throw new IllegalArgumentException("해당 강의에 대한 접근 권한이 없습니다.");
+		}
+	}
+
+}

--- a/src/main/java/com/example/epari/user/domain/Student.java
+++ b/src/main/java/com/example/epari/user/domain/Student.java
@@ -11,13 +11,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@DiscriminatorValue("STUDENT")	//상속 관계에서 학생 타입을 구분하는 값
+@DiscriminatorValue("STUDENT")    //상속 관계에서 학생 타입을 구분하는 값
 @PrimaryKeyJoinColumn(name = "student_id") //부모 테이블의 PK를 참조하는 FK 컬럼명 지정
 @NoArgsConstructor(access = AccessLevel.PROTECTED) //protected 기본 생성자로 무분별한 객체 생성 방지
 @Getter
 public class Student extends BaseUser {
-
-
 
 	private Student(String email, String password, String name, String phoneNumber) {
 		super(email, password, name, phoneNumber, UserRole.STUDENT);


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- ex) Closes #이슈번호 -->
- Closes #45 

## 변경 사항
<!-- 이 PR에서 변경된 주요 내용을 설명해주세요.
     변경사항이 여러 개일 경우, 주요 내용과 하위 항목을 구분하여 작성해주세요. -->
<!-- ex) 1. 000 엔티티 구현 -->
<!--        - 000 메서드 구현 -->
**1. 역할별 시험 조회 기능 구현**
- 강사와 학생의 역할에 따라 시험 조회가 가능하도록 InstructorExamController와 StudentExamController 구현
- InstructorExamService와 StudentExamService를 통해 각 역할에 맞는 비즈니스 로직 분리

**2. 접근 권한 검증 및 최적화**
- 접근 권한을 검증하는 CourseAccessValidator 클래스를 구현하고, 강사의 강의 접근 권한 검증 메소드 `validateInstructorAccess` 및 학생의 강의 접근 권한 검증 메소드 `validateStudentAccess` 추가
- InstructorExamService에 강사의 강의 접근 권한 검증 메소드를 추가하고, 강사 권한이 필요한 시험 생성, 수정, 삭제 기능을 ExamService에서 `InstructorExamService`로 이동
- AttendanceService의 `validateInstructorAccess`를 CourseAccessValidator 클래스를 통해 접근 권한을 검증하도록 리팩토링

**3. 기능 수정 및 리팩토링**
- `@CurrentUserEmail` 어노테이션을 추가하여 컨트롤러에서 이메일 기반의 사용자 식별이 가능하도록 수정
- ExamRepository, InstructorExamService, StudentExamService에서의 역할별 시험 조회 메소드의 쿼리 및 변수명을 `instructorId`, `studentId`에서 `email`로 일관성 있게 변경
- CourseRepository의 쿼리문을 `Course l`에서 `Course c`로 변경하여 일관성을 유지하고, Student 클래스의 빈 공간 제거

## 스크린샷
<!-- (선택) 주요 변경사항(기능 구현 화면, 테스트 결과 등)에 대한 이미지를 삽입해주세요. -->
<!-- 변경사항에 따라 아래 표 템플릿을 활용해주세요 -->
|기능|스크린샷|
|---|---|
|강사가 진행하는 모든 강의 모든 시험 조회|![image](https://github.com/user-attachments/assets/c1e285a0-10b8-48eb-8781-8c67707cca26)|
|학생이 수강하는 모든 강의 모든 시험 조회|![image](https://github.com/user-attachments/assets/890e83b8-3d58-4db0-82d2-409b8763dcc5)|
|강사가 담당하는 강의가 아닐 경우 에러처리|![image](https://github.com/user-attachments/assets/70d9acb6-9969-40a3-b59d-b3e493d2c001)|

## 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항들입니다. -->
- [X] 코드 컨벤션을 준수하였습니까?
- [X] 모든 테스트를 통과하였습니까?
- [X] 관련 문서를 업데이트하였습니까?

## 공유사항
<!-- 리뷰어에게 전달할 추가 정보가 있다면 여기에 적어주세요. -->
접근권한을 검증하는 CourseAccessValidator 클래스를 구현하였습니다. 접근권한 구현 시 global - validator - CourseAccessValidator를 활용하여 주시길 바랍니다.

## 추후 업무
<!-- 추후 진행될 과제에 대해 적어주세요. -->
<!-- ex) [ ] 000 기능 구현 -->
- [ ]  문제 관리 기능(CRUD) 구현 