### PR TITLE
[FEAT] 공지사항 CRUD 구현 후 API로 확인

### DIFF
--- a/src/main/java/com/example/epari/board/controller/FileController.java
+++ b/src/main/java/com/example/epari/board/controller/FileController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.servlet.http.HttpServletRequest;
+
 import java.io.IOException;
 
 @RestController
@@ -37,4 +38,5 @@ public class FileController {
 				.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + resource.getFilename() + "\"")
 				.body(resource);
 	}
+
 }

--- a/src/main/java/com/example/epari/board/controller/FileController.java
+++ b/src/main/java/com/example/epari/board/controller/FileController.java
@@ -1,0 +1,40 @@
+package com.example.epari.board.controller;
+
+import com.example.epari.board.service.FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/files/notices")
+@RequiredArgsConstructor
+public class FileController {
+
+	private final FileService fileService;
+
+	@GetMapping("/{fileName}")
+	public ResponseEntity<Resource> downloadFile(@PathVariable String fileName, HttpServletRequest request) {
+		Resource resource = fileService.loadFileAsResource(fileName);
+
+		String contentType = null;
+		try {
+			contentType = request.getServletContext().getMimeType(resource.getFile().getAbsolutePath());
+		} catch (IOException ex) {
+			contentType = "application/octet-stream";
+		}
+
+		return ResponseEntity.ok()
+				.contentType(MediaType.parseMediaType(contentType))
+				.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + resource.getFilename() + "\"")
+				.body(resource);
+	}
+}

--- a/src/main/java/com/example/epari/board/controller/NoticeController.java
+++ b/src/main/java/com/example/epari/board/controller/NoticeController.java
@@ -7,41 +7,63 @@ import com.example.epari.board.service.NoticeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/notices")
 @RequiredArgsConstructor
 public class NoticeController {
+
 	private final NoticeService noticeService;
 
+	// 공지사항 작성
 	@PostMapping
 	public ResponseEntity<Long> createNotice(@ModelAttribute NoticeRequestDto requestDto) {
 		Long noticeId = noticeService.createNotice(requestDto);
 		return ResponseEntity.ok(noticeId);
 	}
 
-	@DeleteMapping("/{id}")
-	public ResponseEntity<Void> deleteNotice(@PathVariable Long id) {
-		noticeService.deleteNotice(id);
-		return ResponseEntity.ok().build();
+	// 각각의 공지사항 1개 조회
+	@GetMapping("/{id}")
+	public ResponseEntity<NoticeResponseDto> getNotice(@PathVariable Long id) {
+		NoticeResponseDto notice = noticeService.getNotice(id);
+		return ResponseEntity.ok(notice);
 	}
 
+	// 각각의 공지사항 수정
+	@PutMapping("/{id}")
+	public ResponseEntity<Long> updateNotice(@PathVariable Long id, @ModelAttribute NoticeRequestDto requestDto) {
+		Long updatedNoticeId = noticeService.updateNotice(id, requestDto);
+		return ResponseEntity.ok(updatedNoticeId);
+	}
+
+
+	// 공지사항 삭제
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Void> deleteNotice(@PathVariable Long id) {
+		try {    // 예외처리 추가
+			noticeService.deleteNotice(id);
+			return ResponseEntity.ok().build();
+		} catch (RuntimeException e) {
+			return ResponseEntity.notFound().build();
+		}
+	}
+
+	// global 공지사항 전체 조회
 	@GetMapping("/global")
 	public ResponseEntity<List<NoticeResponseDto>> getGlobalNotices() {
 		List<NoticeResponseDto> notices = noticeService.getGlobalNotices();
 		return ResponseEntity.ok(notices);
 	}
 
+
+	// course 공지사항 전체 조회
 	@GetMapping("/course/{courseId}")
 	public ResponseEntity<List<NoticeResponseDto>> getCourseNotices(@PathVariable Long courseId) {
 		List<NoticeResponseDto> notices = noticeService.getCourseNotices(courseId);
 		return ResponseEntity.ok(notices);
 	}
 
-	@GetMapping("/{id}")
-	public ResponseEntity<NoticeResponseDto> getNotice(@PathVariable Long id) {
-		NoticeResponseDto notice = noticeService.getNotice(id);
-		return ResponseEntity.ok(notice);
-	}
+
 }

--- a/src/main/java/com/example/epari/board/controller/NoticeController.java
+++ b/src/main/java/com/example/epari/board/controller/NoticeController.java
@@ -1,0 +1,47 @@
+// NoticeController.java
+package com.example.epari.board.controller;
+
+import com.example.epari.board.dto.NoticeRequestDto;
+import com.example.epari.board.dto.NoticeResponseDto;
+import com.example.epari.board.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notices")
+@RequiredArgsConstructor
+public class NoticeController {
+	private final NoticeService noticeService;
+
+	@PostMapping
+	public ResponseEntity<Long> createNotice(@ModelAttribute NoticeRequestDto requestDto) {
+		Long noticeId = noticeService.createNotice(requestDto);
+		return ResponseEntity.ok(noticeId);
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Void> deleteNotice(@PathVariable Long id) {
+		noticeService.deleteNotice(id);
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/global")
+	public ResponseEntity<List<NoticeResponseDto>> getGlobalNotices() {
+		List<NoticeResponseDto> notices = noticeService.getGlobalNotices();
+		return ResponseEntity.ok(notices);
+	}
+
+	@GetMapping("/course/{courseId}")
+	public ResponseEntity<List<NoticeResponseDto>> getCourseNotices(@PathVariable Long courseId) {
+		List<NoticeResponseDto> notices = noticeService.getCourseNotices(courseId);
+		return ResponseEntity.ok(notices);
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<NoticeResponseDto> getNotice(@PathVariable Long id) {
+		NoticeResponseDto notice = noticeService.getNotice(id);
+		return ResponseEntity.ok(notice);
+	}
+}

--- a/src/main/java/com/example/epari/board/domain/AnswerFile.java
+++ b/src/main/java/com/example/epari/board/domain/AnswerFile.java
@@ -27,7 +27,7 @@ public class AnswerFile extends BaseFile {
 	private Answer answer;
 
 	public static AnswerFile createAnswerFile(String originalFileName, String storedFileName,
-			String fileUrl, Long fileSize, Answer answer) {
+											  String fileUrl, Long fileSize, Answer answer) {
 		AnswerFile file = new AnswerFile(originalFileName, storedFileName, fileUrl, fileSize);
 		file.setAnswer(answer);
 		return file;

--- a/src/main/java/com/example/epari/board/domain/BoardQuestion.java
+++ b/src/main/java/com/example/epari/board/domain/BoardQuestion.java
@@ -76,7 +76,7 @@ public class BoardQuestion extends BaseTimeEntity {
 
 	@Builder
 	private BoardQuestion(String title, String content, BoardQuestionType visibility,
-			Course course, Student student) {
+						  Course course, Student student) {
 		this.title = title;
 		this.content = content;
 		this.visibility = visibility;
@@ -86,7 +86,7 @@ public class BoardQuestion extends BaseTimeEntity {
 	}
 
 	public static BoardQuestion createBoardQuestion(String title, String content,
-			BoardQuestionType visibility, Course course, Student student) {
+													BoardQuestionType visibility, Course course, Student student) {
 		return BoardQuestion.builder()
 				.title(title)
 				.content(content)

--- a/src/main/java/com/example/epari/board/domain/Notice.java
+++ b/src/main/java/com/example/epari/board/domain/Notice.java
@@ -4,23 +4,14 @@ import com.example.epari.course.domain.Course;
 import com.example.epari.global.common.base.BaseTimeEntity;
 import com.example.epari.global.common.enums.NoticeType;
 import com.example.epari.user.domain.Instructor;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 강의 공지사항을 관리하는 엔티티
@@ -49,6 +40,10 @@ public class Notice extends BaseTimeEntity {
 	@Column(nullable = false)
 	private NoticeType type;
 
+	// files 필드 추가
+	@OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<NoticeFile> files = new ArrayList<>();
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "course_id", nullable = false)
 	private Course course;
@@ -74,6 +69,14 @@ public class Notice extends BaseTimeEntity {
 	public void update(String title, String content) {
 		this.title = title;
 		this.content = content;
+	}
+
+	// 파일 추가 메서드
+	public void addFile(NoticeFile file) {
+		this.files.add(file);
+		if (file.getNotice() != this) {
+			file.setNotice(this);
+		}
 	}
 
 }

--- a/src/main/java/com/example/epari/board/domain/Notice.java
+++ b/src/main/java/com/example/epari/board/domain/Notice.java
@@ -79,4 +79,13 @@ public class Notice extends BaseTimeEntity {
 		}
 	}
 
+	
+	// 공지사항 업데이트
+	public void update(String title, String content, NoticeType type, Course course) {
+		this.title = title;
+		this.content = content;
+		this.type = type;
+		this.course = course;
+	}
+
 }

--- a/src/main/java/com/example/epari/board/domain/NoticeFile.java
+++ b/src/main/java/com/example/epari/board/domain/NoticeFile.java
@@ -27,7 +27,7 @@ public class NoticeFile extends BaseFile {
 	private Notice notice;
 
 	public static NoticeFile createNoticeFile(String originalFileName, String storedFileName,
-			String fileUrl, Long fileSize, Notice notice) {
+											  String fileUrl, Long fileSize, Notice notice) {
 		NoticeFile file = new NoticeFile(originalFileName, storedFileName, fileUrl, fileSize);
 		file.setNotice(notice);
 		return file;
@@ -37,8 +37,16 @@ public class NoticeFile extends BaseFile {
 		super(originalFileName, storedFileName, fileUrl, fileSize);
 	}
 
-	private void setNotice(Notice notice) {
+	public void setNotice(Notice notice) {
+		// 기존 관계 제거
+		if (this.notice != null) {
+			this.notice.getFiles().remove(this);
+		}
 		this.notice = notice;
+		// 새로운 관계 설정
+		if (notice != null && !notice.getFiles().contains(this)) {
+			notice.getFiles().add(this);
+		}
 	}
 
 }

--- a/src/main/java/com/example/epari/board/domain/NoticeFile.java
+++ b/src/main/java/com/example/epari/board/domain/NoticeFile.java
@@ -1,20 +1,16 @@
 package com.example.epari.board.domain;
 
 import com.example.epari.global.common.base.BaseFile;
-
-import jakarta.persistence.DiscriminatorValue;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 /**
  * 공지사항 첨부파일 관리 엔티티
  */
+
 @Entity
 @DiscriminatorValue("NOTICE_FILE")
 @PrimaryKeyJoinColumn(name = "notice_file_id")
@@ -26,15 +22,15 @@ public class NoticeFile extends BaseFile {
 	@JoinColumn(name = "notice_id")
 	private Notice notice;
 
+	private NoticeFile(String originalFileName, String storedFileName, String fileUrl, Long fileSize) {
+		super(originalFileName, storedFileName, fileUrl, fileSize);
+	}
+
 	public static NoticeFile createNoticeFile(String originalFileName, String storedFileName,
 											  String fileUrl, Long fileSize, Notice notice) {
 		NoticeFile file = new NoticeFile(originalFileName, storedFileName, fileUrl, fileSize);
 		file.setNotice(notice);
 		return file;
-	}
-
-	private NoticeFile(String originalFileName, String storedFileName, String fileUrl, Long fileSize) {
-		super(originalFileName, storedFileName, fileUrl, fileSize);
 	}
 
 	public void setNotice(Notice notice) {
@@ -48,5 +44,4 @@ public class NoticeFile extends BaseFile {
 			notice.getFiles().add(this);
 		}
 	}
-
 }

--- a/src/main/java/com/example/epari/board/domain/NoticeFile.java
+++ b/src/main/java/com/example/epari/board/domain/NoticeFile.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class NoticeFile {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -21,6 +22,7 @@ public class NoticeFile {
 
 	private String storedFileName;
 
+	@Column(length = 2048)  // URL 길이를 2048로 증가
 	private String fileUrl;  // 추가된 필드
 
 	private Long fileSize;
@@ -57,60 +59,5 @@ public class NoticeFile {
 	public void updateFileUrl(String fileUrl) {
 		this.fileUrl = fileUrl;
 	}
+
 }
-
-
-
-//package com.example.epari.board.domain;
-//
-//import com.example.epari.global.common.base.BaseFile;
-//import jakarta.persistence.*;
-//import lombok.AccessLevel;
-//import lombok.Getter;
-//import lombok.NoArgsConstructor;
-//
-//
-///**
-// * 공지사항 첨부파일 관리 엔티티
-// */
-//
-//@Entity
-//@DiscriminatorValue("NOTICE_FILE")
-//@PrimaryKeyJoinColumn(name = "notice_file_id")
-//@Getter
-//@NoArgsConstructor(access = AccessLevel.PROTECTED)
-//public class NoticeFile extends BaseFile {
-//
-//	@ManyToOne(fetch = FetchType.LAZY)
-//	@JoinColumn(name = "notice_id")
-//	private Notice notice;
-//
-//	private NoticeFile(String originalFileName, String storedFileName, String fileUrl, Long fileSize) {
-//		super(originalFileName, storedFileName, fileUrl, fileSize);
-//	}
-//
-//	public static NoticeFile createNoticeFile(String originalFileName, String storedFileName,
-//											  String fileUrl, Long fileSize, Notice notice) {
-//		NoticeFile file = new NoticeFile(originalFileName, storedFileName, fileUrl, fileSize);
-//		file.setNotice(notice);
-//		return file;
-//	}
-//
-//	public void setNotice(Notice notice) {
-//		// 기존 관계 제거
-//		if (this.notice != null) {
-//			this.notice.getFiles().remove(this);
-//		}
-//		this.notice = notice;
-//		// 새로운 관계 설정
-//		if (notice != null && !notice.getFiles().contains(this)) {
-//			notice.getFiles().add(this);
-//		}
-//	}
-//
-//	// s3
-//	public void updateFileUrl(String fileUrl) {
-//		this.fileUrl = fileUrl;
-//	}
-//
-//}

--- a/src/main/java/com/example/epari/board/domain/NoticeFile.java
+++ b/src/main/java/com/example/epari/board/domain/NoticeFile.java
@@ -44,4 +44,5 @@ public class NoticeFile extends BaseFile {
 			notice.getFiles().add(this);
 		}
 	}
+
 }

--- a/src/main/java/com/example/epari/board/domain/NoticeFile.java
+++ b/src/main/java/com/example/epari/board/domain/NoticeFile.java
@@ -1,48 +1,116 @@
 package com.example.epari.board.domain;
 
-import com.example.epari.global.common.base.BaseFile;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
-/**
- * 공지사항 첨부파일 관리 엔티티
- */
-
 @Entity
-@DiscriminatorValue("NOTICE_FILE")
-@PrimaryKeyJoinColumn(name = "notice_file_id")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NoticeFile extends BaseFile {
+@NoArgsConstructor
+public class NoticeFile {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "notice_id")
 	private Notice notice;
 
-	private NoticeFile(String originalFileName, String storedFileName, String fileUrl, Long fileSize) {
-		super(originalFileName, storedFileName, fileUrl, fileSize);
+	private String originalFileName;
+
+	private String storedFileName;
+
+	private String fileUrl;  // 추가된 필드
+
+	private Long fileSize;
+
+	@Builder
+	public NoticeFile(String originalFileName, String storedFileName, String fileUrl, Long fileSize) {
+		this.originalFileName = originalFileName;
+		this.storedFileName = storedFileName;
+		this.fileUrl = fileUrl;
+		this.fileSize = fileSize;
 	}
 
-	public static NoticeFile createNoticeFile(String originalFileName, String storedFileName,
-											  String fileUrl, Long fileSize, Notice notice) {
-		NoticeFile file = new NoticeFile(originalFileName, storedFileName, fileUrl, fileSize);
-		file.setNotice(notice);
-		return file;
+	public static NoticeFile createNoticeFile(
+			String originalFileName,
+			String storedFileName,
+			String fileUrl,
+			Long fileSize,
+			Notice notice
+	) {
+		NoticeFile noticeFile = NoticeFile.builder()
+				.originalFileName(originalFileName)
+				.storedFileName(storedFileName)
+				.fileUrl(fileUrl)
+				.fileSize(fileSize)
+				.build();
+		noticeFile.setNotice(notice);
+		return noticeFile;
 	}
 
 	public void setNotice(Notice notice) {
-		// 기존 관계 제거
-		if (this.notice != null) {
-			this.notice.getFiles().remove(this);
-		}
 		this.notice = notice;
-		// 새로운 관계 설정
-		if (notice != null && !notice.getFiles().contains(this)) {
-			notice.getFiles().add(this);
-		}
 	}
 
+	public void updateFileUrl(String fileUrl) {
+		this.fileUrl = fileUrl;
+	}
 }
+
+
+
+//package com.example.epari.board.domain;
+//
+//import com.example.epari.global.common.base.BaseFile;
+//import jakarta.persistence.*;
+//import lombok.AccessLevel;
+//import lombok.Getter;
+//import lombok.NoArgsConstructor;
+//
+//
+///**
+// * 공지사항 첨부파일 관리 엔티티
+// */
+//
+//@Entity
+//@DiscriminatorValue("NOTICE_FILE")
+//@PrimaryKeyJoinColumn(name = "notice_file_id")
+//@Getter
+//@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//public class NoticeFile extends BaseFile {
+//
+//	@ManyToOne(fetch = FetchType.LAZY)
+//	@JoinColumn(name = "notice_id")
+//	private Notice notice;
+//
+//	private NoticeFile(String originalFileName, String storedFileName, String fileUrl, Long fileSize) {
+//		super(originalFileName, storedFileName, fileUrl, fileSize);
+//	}
+//
+//	public static NoticeFile createNoticeFile(String originalFileName, String storedFileName,
+//											  String fileUrl, Long fileSize, Notice notice) {
+//		NoticeFile file = new NoticeFile(originalFileName, storedFileName, fileUrl, fileSize);
+//		file.setNotice(notice);
+//		return file;
+//	}
+//
+//	public void setNotice(Notice notice) {
+//		// 기존 관계 제거
+//		if (this.notice != null) {
+//			this.notice.getFiles().remove(this);
+//		}
+//		this.notice = notice;
+//		// 새로운 관계 설정
+//		if (notice != null && !notice.getFiles().contains(this)) {
+//			notice.getFiles().add(this);
+//		}
+//	}
+//
+//	// s3
+//	public void updateFileUrl(String fileUrl) {
+//		this.fileUrl = fileUrl;
+//	}
+//
+//}

--- a/src/main/java/com/example/epari/board/domain/QuestionFile.java
+++ b/src/main/java/com/example/epari/board/domain/QuestionFile.java
@@ -27,7 +27,7 @@ public class QuestionFile extends BaseFile {
 	private BoardQuestion boardQuestion;
 
 	public static QuestionFile createQuestionFile(String originalFileName, String storedFileName,
-			String fileUrl, Long fileSize, BoardQuestion boardQuestion) {
+												  String fileUrl, Long fileSize, BoardQuestion boardQuestion) {
 		QuestionFile file = new QuestionFile(originalFileName, storedFileName, fileUrl, fileSize);
 		file.setBoardQuestion(boardQuestion);
 		return file;

--- a/src/main/java/com/example/epari/board/dto/FileInfoDto.java
+++ b/src/main/java/com/example/epari/board/dto/FileInfoDto.java
@@ -1,0 +1,18 @@
+package com.example.epari.board.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FileInfoDto {
+
+	private String originalFileName;  // 원본 파일명
+
+	private String storedFileName;    // 저장된 파일명
+
+	private long fileSize;            // 파일 크기
+
+	private String fileUrl;           // 파일 접근 URL
+
+}

--- a/src/main/java/com/example/epari/board/dto/NoticeFileDto.java
+++ b/src/main/java/com/example/epari/board/dto/NoticeFileDto.java
@@ -9,9 +9,13 @@ import lombok.AccessLevel;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NoticeFileDto {
+
 	private Long id;
+
 	private String originalFileName;
+
 	private String fileUrl;
+
 	private Long fileSize;
 
 	@Builder
@@ -30,4 +34,5 @@ public class NoticeFileDto {
 				.fileSize(noticeFile.getFileSize())
 				.build();
 	}
+
 }

--- a/src/main/java/com/example/epari/board/dto/NoticeFileDto.java
+++ b/src/main/java/com/example/epari/board/dto/NoticeFileDto.java
@@ -1,0 +1,33 @@
+package com.example.epari.board.dto;
+
+import com.example.epari.board.domain.NoticeFile;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeFileDto {
+	private Long id;
+	private String originalFileName;
+	private String fileUrl;
+	private Long fileSize;
+
+	@Builder
+	public NoticeFileDto(Long id, String originalFileName, String fileUrl, Long fileSize) {
+		this.id = id;
+		this.originalFileName = originalFileName;
+		this.fileUrl = fileUrl;
+		this.fileSize = fileSize;
+	}
+
+	public static NoticeFileDto from(NoticeFile noticeFile) {
+		return NoticeFileDto.builder()
+				.id(noticeFile.getId())
+				.originalFileName(noticeFile.getOriginalFileName())
+				.fileUrl(noticeFile.getFileUrl())
+				.fileSize(noticeFile.getFileSize())
+				.build();
+	}
+}

--- a/src/main/java/com/example/epari/board/dto/NoticeRequestDto.java
+++ b/src/main/java/com/example/epari/board/dto/NoticeRequestDto.java
@@ -27,6 +27,8 @@ public class NoticeRequestDto {
 
 	private List<MultipartFile> files; // 파일 업로드를 위한 필드
 
+	private List<Long> deleteFileIds; // 삭제할 파일 ID 목록
+
 	@Builder
 	public NoticeRequestDto(String title, String content, NoticeType type,
 							Long courseId, Long instructorId, List<MultipartFile> files) {

--- a/src/main/java/com/example/epari/board/dto/NoticeRequestDto.java
+++ b/src/main/java/com/example/epari/board/dto/NoticeRequestDto.java
@@ -2,6 +2,7 @@ package com.example.epari.board.dto;
 
 
 import com.example.epari.global.common.enums.NoticeType;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,14 +16,19 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NoticeRequestDto {
 
+	@NotNull
 	private String title;
 
+	@NotNull
 	private String content;
 
+	@NotNull
 	private NoticeType type;
 
+	@NotNull
 	private Long courseId;
 
+	@NotNull
 	private Long instructorId;
 
 	private List<MultipartFile> files; // 파일 업로드를 위한 필드

--- a/src/main/java/com/example/epari/board/dto/NoticeRequestDto.java
+++ b/src/main/java/com/example/epari/board/dto/NoticeRequestDto.java
@@ -1,0 +1,41 @@
+package com.example.epari.board.dto;
+
+
+import com.example.epari.global.common.enums.NoticeType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+// NoticeRequestDto : 공지사항 등록 Dto
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoticeRequestDto {
+
+	private String title;
+
+	private String content;
+
+	private NoticeType type;
+
+	private Long courseId;
+
+	private Long instructorId;
+
+	private List<MultipartFile> files; // 파일 업로드를 위한 필드
+
+	@Builder
+	public NoticeRequestDto(String title, String content, NoticeType type,
+							Long courseId, Long instructorId, List<MultipartFile> files) {
+		this.title = title;
+		this.content = content;
+		this.type = type;
+		this.courseId = courseId;
+		this.instructorId = instructorId;
+		this.files = files;
+	}
+
+}

--- a/src/main/java/com/example/epari/board/dto/NoticeRequestDto.java
+++ b/src/main/java/com/example/epari/board/dto/NoticeRequestDto.java
@@ -2,7 +2,6 @@ package com.example.epari.board.dto;
 
 
 import com.example.epari.global.common.enums.NoticeType;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,19 +15,14 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NoticeRequestDto {
 
-	@NotNull
 	private String title;
 
-	@NotNull
 	private String content;
 
-	@NotNull
 	private NoticeType type;
 
-	@NotNull
 	private Long courseId;
 
-	@NotNull
 	private Long instructorId;
 
 	private List<MultipartFile> files; // 파일 업로드를 위한 필드

--- a/src/main/java/com/example/epari/board/dto/NoticeResponseDto.java
+++ b/src/main/java/com/example/epari/board/dto/NoticeResponseDto.java
@@ -1,0 +1,72 @@
+package com.example.epari.board.dto;
+
+import com.example.epari.board.domain.Notice;
+import com.example.epari.global.common.enums.NoticeType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+
+//
+
+@Getter
+public class NoticeResponseDto {
+
+	private Long displayNumber; // 화면에 보여줄 번호 (공지사항 타입별로 따로 관리)
+
+	private Long id; // 실제 DB ID
+
+	private String title;
+
+	private String content;
+
+	private NoticeType type;
+
+	private Integer viewCount;
+
+	private LocalDateTime createdAt;
+
+	private String instructorName;
+
+	private List<NoticeFileDto> files;
+
+	@Builder
+	public NoticeResponseDto(Long displayNumber, Long id, String title, String content,
+							 NoticeType type, Integer viewCount, LocalDateTime createdAt,
+							 String instructorName, List<NoticeFileDto> files) {
+		this.displayNumber = displayNumber;
+		this.id = id;
+		this.title = title;
+		this.content = content;
+		this.type = type;
+		this.viewCount = viewCount;
+		this.createdAt = createdAt;
+		this.instructorName = instructorName;
+		this.files = files;
+	}
+
+	public static List<NoticeResponseDto> fromNotices(List<Notice> notices) {
+		AtomicLong counter = new AtomicLong(notices.size());
+
+		return notices.stream()
+				.map(notice -> NoticeResponseDto.builder()
+						.displayNumber(counter.getAndDecrement())
+						.id(notice.getId())
+						.title(notice.getTitle())
+						.content(notice.getContent())
+						.type(notice.getType())
+						.viewCount(notice.getViewCount())
+						.createdAt(notice.getCreatedAt())
+						.instructorName(notice.getInstructor().getName())
+						.files(notice.getFiles().stream()
+								.map(NoticeFileDto::from)
+								.collect(Collectors.toList()))
+						.build())
+				.collect(Collectors.toList());
+	}
+
+}

--- a/src/main/java/com/example/epari/board/repository/NoticeFileRepository.java
+++ b/src/main/java/com/example/epari/board/repository/NoticeFileRepository.java
@@ -1,0 +1,16 @@
+package com.example.epari.board.repository;
+
+import com.example.epari.board.domain.NoticeFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NoticeFileRepository extends JpaRepository<NoticeFile, Long> {
+
+	List<NoticeFile> findByNoticeId(Long noticeId);
+
+	void deleteByNoticeId(Long noticeId);
+
+}

--- a/src/main/java/com/example/epari/board/repository/NoticeRepository.java
+++ b/src/main/java/com/example/epari/board/repository/NoticeRepository.java
@@ -14,6 +14,8 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 	List<Notice> findByTypeOrderByCreatedAtDesc(NoticeType type);
 
 	List<Notice> findByCourseIdOrderByCreatedAtDesc(Long courseId);
+	List<Notice> findByCourseIdAndTypeOrderByCreatedAtDesc(Long courseId, NoticeType type);
+
 
 	Optional<Notice> findByIdAndType(Long id, NoticeType type);
 

--- a/src/main/java/com/example/epari/board/repository/NoticeRepository.java
+++ b/src/main/java/com/example/epari/board/repository/NoticeRepository.java
@@ -14,6 +14,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 	List<Notice> findByTypeOrderByCreatedAtDesc(NoticeType type);
 
 	List<Notice> findByCourseIdOrderByCreatedAtDesc(Long courseId);
+
 	List<Notice> findByCourseIdAndTypeOrderByCreatedAtDesc(Long courseId, NoticeType type);
 
 

--- a/src/main/java/com/example/epari/board/repository/NoticeRepository.java
+++ b/src/main/java/com/example/epari/board/repository/NoticeRepository.java
@@ -1,0 +1,20 @@
+package com.example.epari.board.repository;
+
+import com.example.epari.board.domain.Notice;
+import com.example.epari.global.common.enums.NoticeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+	List<Notice> findByTypeOrderByCreatedAtDesc(NoticeType type);
+
+	List<Notice> findByCourseIdOrderByCreatedAtDesc(Long courseId);
+
+	Optional<Notice> findByIdAndType(Long id, NoticeType type);
+
+}

--- a/src/main/java/com/example/epari/board/service/FileService.java
+++ b/src/main/java/com/example/epari/board/service/FileService.java
@@ -1,0 +1,53 @@
+// FileService.java
+package com.example.epari.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+	@Value("${file.upload.notice}")
+	private String uploadDir;
+
+	public String storeFile(MultipartFile file) {
+		String originalFileName = file.getOriginalFilename();
+		String storedFileName = createStoredFileName(originalFileName);
+
+		try {
+			Path targetLocation = Path.of(uploadDir).resolve(storedFileName);
+			Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+			return storedFileName;
+		} catch (IOException ex) {
+			throw new RuntimeException("Could not store file " + originalFileName, ex);
+		}
+	}
+
+	public void deleteFile(String storedFileName) {
+		try {
+			Path filePath = Path.of(uploadDir).resolve(storedFileName);
+			Files.deleteIfExists(filePath);
+		} catch (IOException ex) {
+			throw new RuntimeException("Could not delete file " + storedFileName, ex);
+		}
+	}
+
+	public String getFileUrl(String storedFileName) {
+		return "/files/" + storedFileName;
+	}
+
+	private String createStoredFileName(String originalFileName) {
+		String ext = originalFileName.substring(originalFileName.lastIndexOf("."));
+		return UUID.randomUUID().toString() + ext;
+	}
+
+}

--- a/src/main/java/com/example/epari/board/service/FileService.java
+++ b/src/main/java/com/example/epari/board/service/FileService.java
@@ -108,4 +108,5 @@ public class FileService {
 	private String generateFileUrl(String storedFileName) {
 		return "/api/files/notices/" + storedFileName;
 	}
+
 }

--- a/src/main/java/com/example/epari/board/service/FileService.java
+++ b/src/main/java/com/example/epari/board/service/FileService.java
@@ -24,7 +24,13 @@ public class FileService {
 		String storedFileName = createStoredFileName(originalFileName);
 
 		try {
-			Path targetLocation = Path.of(uploadDir).resolve(storedFileName);
+			// 디렉토리가 없으면 생성
+			Path uploadPath = Path.of(uploadDir);
+			if (!Files.exists(uploadPath)) {
+				Files.createDirectories(uploadPath);
+			}
+
+			Path targetLocation = uploadPath.resolve(storedFileName);
 			Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
 			return storedFileName;
 		} catch (IOException ex) {

--- a/src/main/java/com/example/epari/board/service/FileService.java
+++ b/src/main/java/com/example/epari/board/service/FileService.java
@@ -24,13 +24,7 @@ public class FileService {
 		String storedFileName = createStoredFileName(originalFileName);
 
 		try {
-			// 디렉토리가 없으면 생성
-			Path uploadPath = Path.of(uploadDir);
-			if (!Files.exists(uploadPath)) {
-				Files.createDirectories(uploadPath);
-			}
-
-			Path targetLocation = uploadPath.resolve(storedFileName);
+			Path targetLocation = Path.of(uploadDir).resolve(storedFileName);
 			Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
 			return storedFileName;
 		} catch (IOException ex) {

--- a/src/main/java/com/example/epari/board/service/FileService.java
+++ b/src/main/java/com/example/epari/board/service/FileService.java
@@ -1,12 +1,16 @@
-// FileService.java
 package com.example.epari.board.service;
 
+import com.example.epari.board.dto.FileInfoDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -21,10 +25,15 @@ public class FileService {
 
 	public String storeFile(MultipartFile file) {
 		String originalFileName = file.getOriginalFilename();
-		String storedFileName = createStoredFileName(originalFileName);
+		String storedFileName = generateStoredFileName(originalFileName);
 
 		try {
-			Path targetLocation = Path.of(uploadDir).resolve(storedFileName);
+			File directory = new File(uploadDir);
+			if (!directory.exists()) {
+				directory.mkdirs();
+			}
+
+			Path targetLocation = Path.of(uploadDir, storedFileName);
 			Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
 			return storedFileName;
 		} catch (IOException ex) {
@@ -32,22 +41,71 @@ public class FileService {
 		}
 	}
 
+	public String getFileUrl(String storedFileName) {
+		return "/api/files/notices/" + storedFileName;
+	}
+
+	public Resource loadFileAsResource(String fileName) {
+		try {
+			Path filePath = Path.of(uploadDir, fileName);
+			Resource resource = new UrlResource(filePath.toUri());
+			if (resource.exists()) {
+				return resource;
+			} else {
+				throw new RuntimeException("File not found: " + fileName);
+			}
+		} catch (MalformedURLException ex) {
+			throw new RuntimeException("File not found: " + fileName);
+		}
+	}
+
+	public FileInfoDto uploadFile(MultipartFile file) {
+		if (file.isEmpty()) {
+			throw new IllegalArgumentException("File is empty");
+		}
+
+		String originalFileName = file.getOriginalFilename();
+		String storedFileName = generateStoredFileName(originalFileName);
+		String fileUrl = generateFileUrl(storedFileName);
+
+		try {
+			File directory = new File(uploadDir);
+			if (!directory.exists()) {
+				directory.mkdirs();
+			}
+
+			Path targetLocation = Path.of(uploadDir, storedFileName);
+			Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+
+			return FileInfoDto.builder()
+					.originalFileName(originalFileName)
+					.storedFileName(storedFileName)
+					.fileSize(file.getSize())
+					.fileUrl(fileUrl)
+					.build();
+		} catch (IOException ex) {
+			throw new RuntimeException("Could not store file " + originalFileName, ex);
+		}
+	}
+
 	public void deleteFile(String storedFileName) {
 		try {
-			Path filePath = Path.of(uploadDir).resolve(storedFileName);
+			Path filePath = Path.of(uploadDir, storedFileName);
 			Files.deleteIfExists(filePath);
 		} catch (IOException ex) {
 			throw new RuntimeException("Could not delete file " + storedFileName, ex);
 		}
 	}
 
-	public String getFileUrl(String storedFileName) {
-		return "/files/" + storedFileName;
+	private String generateStoredFileName(String originalFileName) {
+		return UUID.randomUUID().toString() + getFileExtension(originalFileName);
 	}
 
-	private String createStoredFileName(String originalFileName) {
-		String ext = originalFileName.substring(originalFileName.lastIndexOf("."));
-		return UUID.randomUUID().toString() + ext;
+	private String getFileExtension(String fileName) {
+		return fileName.substring(fileName.lastIndexOf("."));
 	}
 
+	private String generateFileUrl(String storedFileName) {
+		return "/api/files/notices/" + storedFileName;
+	}
 }

--- a/src/main/java/com/example/epari/board/service/NoticeService.java
+++ b/src/main/java/com/example/epari/board/service/NoticeService.java
@@ -1,8 +1,8 @@
-// NoticeService.java
 package com.example.epari.board.service;
 
 import com.example.epari.board.domain.Notice;
 import com.example.epari.board.domain.NoticeFile;
+import com.example.epari.board.dto.FileInfoDto;
 import com.example.epari.board.dto.NoticeRequestDto;
 import com.example.epari.board.dto.NoticeResponseDto;
 import com.example.epari.board.repository.NoticeRepository;
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -47,14 +48,15 @@ public class NoticeService {
 				.instructor(instructor)
 				.build());
 
+		// 파일 처리
 		if (requestDto.getFiles() != null && !requestDto.getFiles().isEmpty()) {
 			for (MultipartFile file : requestDto.getFiles()) {
-				String storedFileName = fileService.storeFile(file);
+				FileInfoDto fileInfo = fileService.uploadFile(file);
 				NoticeFile noticeFile = NoticeFile.createNoticeFile(
-						file.getOriginalFilename(),
-						storedFileName,
-						fileService.getFileUrl(storedFileName),
-						file.getSize(),
+						fileInfo.getOriginalFileName(),
+						fileInfo.getStoredFileName(),
+						fileInfo.getFileUrl(),
+						fileInfo.getFileSize(),
 						notice
 				);
 				noticeFileRepository.save(noticeFile);
@@ -65,10 +67,59 @@ public class NoticeService {
 	}
 
 	@Transactional
+	public Long updateNotice(Long id, NoticeRequestDto requestDto) {
+		Notice notice = noticeRepository.findById(id)
+				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
+
+		Course course = courseRepository.findById(requestDto.getCourseId())
+				.orElseThrow(() -> new EntityNotFoundException("Course not found"));
+
+		// 삭제될 파일 처리
+		if (requestDto.getDeleteFileIds() != null && !requestDto.getDeleteFileIds().isEmpty()) {
+			for (Long fileId : requestDto.getDeleteFileIds()) {
+				NoticeFile fileToDelete = notice.getFiles().stream()
+						.filter(file -> file.getId().equals(fileId))
+						.findFirst()
+						.orElseThrow(() -> new EntityNotFoundException("File not found"));
+
+				// 실제 파일 삭제
+				fileService.deleteFile(fileToDelete.getStoredFileName());
+				notice.getFiles().remove(fileToDelete);
+			}
+		}
+
+		// 새로운 파일 추가
+		if (requestDto.getFiles() != null && !requestDto.getFiles().isEmpty()) {
+			for (MultipartFile file : requestDto.getFiles()) {
+				FileInfoDto fileInfo = fileService.uploadFile(file);
+				NoticeFile noticeFile = NoticeFile.createNoticeFile(
+						fileInfo.getOriginalFileName(),
+						fileInfo.getStoredFileName(),
+						fileInfo.getFileUrl(),
+						fileInfo.getFileSize(),
+						notice
+				);
+				notice.getFiles().add(noticeFile);
+			}
+		}
+
+		// 공지사항 정보 업데이트
+		notice.update(
+				requestDto.getTitle(),
+				requestDto.getContent(),
+				requestDto.getType(),
+				course
+		);
+
+		return notice.getId();
+	}
+
+	@Transactional
 	public void deleteNotice(Long noticeId) {
 		Notice notice = noticeRepository.findById(noticeId)
 				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
 
+		// 연관된 파일들 삭제
 		List<NoticeFile> files = noticeFileRepository.findByNoticeId(noticeId);
 		files.forEach(file -> fileService.deleteFile(file.getStoredFileName()));
 
@@ -81,7 +132,7 @@ public class NoticeService {
 	}
 
 	public List<NoticeResponseDto> getCourseNotices(Long courseId) {
-		List<Notice> notices = noticeRepository.findByCourseIdOrderByCreatedAtDesc(courseId);
+		List<Notice> notices = noticeRepository.findByCourseIdAndTypeOrderByCreatedAtDesc(courseId, NoticeType.COURSE);
 		return NoticeResponseDto.fromNotices(notices);
 	}
 

--- a/src/main/java/com/example/epari/board/service/NoticeService.java
+++ b/src/main/java/com/example/epari/board/service/NoticeService.java
@@ -2,7 +2,6 @@ package com.example.epari.board.service;
 
 import com.example.epari.board.domain.Notice;
 import com.example.epari.board.domain.NoticeFile;
-import com.example.epari.board.dto.FileInfoDto;
 import com.example.epari.board.dto.NoticeRequestDto;
 import com.example.epari.board.dto.NoticeResponseDto;
 import com.example.epari.board.repository.NoticeRepository;
@@ -10,6 +9,8 @@ import com.example.epari.board.repository.NoticeFileRepository;
 import com.example.epari.course.domain.Course;
 import com.example.epari.course.repository.CourseRepository;
 import com.example.epari.global.common.enums.NoticeType;
+import com.example.epari.global.common.service.S3FileService;
+import com.example.epari.global.config.aws.AwsS3Properties;
 import com.example.epari.user.domain.Instructor;
 import com.example.epari.user.repository.InstructorRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,15 +29,13 @@ import java.util.List;
 public class NoticeService {
 
 	private final NoticeRepository noticeRepository;
-
 	private final NoticeFileRepository noticeFileRepository;
-
 	private final CourseRepository courseRepository;
-
 	private final InstructorRepository instructorRepository;
+	private final S3FileService s3FileService;
+	private final AwsS3Properties awsS3Properties;  // S3 설정값을 가져오기 위해 추가
 
-	private final FileService fileService;
-
+	// 1. 공지사항 작성
 	@Transactional
 	public Long createNotice(NoticeRequestDto requestDto) {
 		Course course = courseRepository.findById(requestDto.getCourseId())
@@ -53,15 +52,15 @@ public class NoticeService {
 				.instructor(instructor)
 				.build());
 
-		// 파일 처리
+		// S3에 파일 업로드
 		if (requestDto.getFiles() != null && !requestDto.getFiles().isEmpty()) {
 			for (MultipartFile file : requestDto.getFiles()) {
-				FileInfoDto fileInfo = fileService.uploadFile(file);
+				String fileUrl = s3FileService.uploadFile("notices", file);
 				NoticeFile noticeFile = NoticeFile.createNoticeFile(
-						fileInfo.getOriginalFileName(),
-						fileInfo.getStoredFileName(),
-						fileInfo.getFileUrl(),
-						fileInfo.getFileSize(),
+						file.getOriginalFilename(),
+						extractKeyFromUrl(fileUrl),
+						fileUrl,
+						file.getSize(),
 						notice
 				);
 				noticeFileRepository.save(noticeFile);
@@ -71,6 +70,7 @@ public class NoticeService {
 		return notice.getId();
 	}
 
+	// 2. 공지사항 수정
 	@Transactional
 	public Long updateNotice(Long id, NoticeRequestDto requestDto) {
 		Notice notice = noticeRepository.findById(id)
@@ -87,8 +87,8 @@ public class NoticeService {
 						.findFirst()
 						.orElseThrow(() -> new EntityNotFoundException("File not found"));
 
-				// 실제 파일 삭제
-				fileService.deleteFile(fileToDelete.getStoredFileName());
+				// S3에서 파일 삭제
+				s3FileService.deleteFile(fileToDelete.getFileUrl());
 				notice.getFiles().remove(fileToDelete);
 			}
 		}
@@ -96,19 +96,18 @@ public class NoticeService {
 		// 새로운 파일 추가
 		if (requestDto.getFiles() != null && !requestDto.getFiles().isEmpty()) {
 			for (MultipartFile file : requestDto.getFiles()) {
-				FileInfoDto fileInfo = fileService.uploadFile(file);
+				String fileUrl = s3FileService.uploadFile("notices", file);
 				NoticeFile noticeFile = NoticeFile.createNoticeFile(
-						fileInfo.getOriginalFileName(),
-						fileInfo.getStoredFileName(),
-						fileInfo.getFileUrl(),
-						fileInfo.getFileSize(),
+						file.getOriginalFilename(),
+						extractKeyFromUrl(fileUrl),
+						fileUrl,
+						file.getSize(),
 						notice
 				);
 				notice.getFiles().add(noticeFile);
 			}
 		}
 
-		// 공지사항 정보 업데이트
 		notice.update(
 				requestDto.getTitle(),
 				requestDto.getContent(),
@@ -119,37 +118,359 @@ public class NoticeService {
 		return notice.getId();
 	}
 
+	// 3. 공지사항 삭제
 	@Transactional
 	public void deleteNotice(Long noticeId) {
 		Notice notice = noticeRepository.findById(noticeId)
 				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
 
-		// 연관된 파일들 삭제
+		// S3에서 파일 삭제
 		List<NoticeFile> files = noticeFileRepository.findByNoticeId(noticeId);
-		files.forEach(file -> fileService.deleteFile(file.getStoredFileName()));
+		files.forEach(file -> s3FileService.deleteFile(file.getFileUrl()));
 
 		noticeRepository.delete(notice);
 	}
 
-	public List<NoticeResponseDto> getGlobalNotices() {
-		List<Notice> notices = noticeRepository.findByTypeOrderByCreatedAtDesc(NoticeType.GLOBAL);
-		return NoticeResponseDto.fromNotices(notices);
-	}
-
-	public List<NoticeResponseDto> getCourseNotices(Long courseId) {
-		List<Notice> notices = noticeRepository.findByCourseIdAndTypeOrderByCreatedAtDesc(courseId, NoticeType.COURSE);
-		return NoticeResponseDto.fromNotices(notices);
-	}
-
+	// 4. 단일 공지사항 조회 (상세보기)
 	@Transactional
 	public NoticeResponseDto getNotice(Long noticeId) {
 		Notice notice = noticeRepository.findById(noticeId)
 				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
 
-		notice.increaseViewCount();
+		notice.increaseViewCount();  // 조회수 증가
+
+		// 파일들의 Presigned URL 생성
+		notice.getFiles().forEach(file -> {
+			String presignedUrl = s3FileService.generatePresignedUrl(file.getFileUrl(), Duration.ofHours(1));
+			file.updateFileUrl(presignedUrl);
+		});
 
 		List<Notice> singletonList = Collections.singletonList(notice);
 		return NoticeResponseDto.fromNotices(singletonList).get(0);
 	}
 
+	// 5. 전체 글로벌 공지사항 조회 (추가된 메서드)
+	public List<NoticeResponseDto> getGlobalNotices() {
+		List<Notice> notices = noticeRepository.findByTypeOrderByCreatedAtDesc(NoticeType.GLOBAL);
+
+		// 각 공지사항의 파일들에 대해 Presigned URL 생성
+		notices.forEach(notice ->
+				notice.getFiles().forEach(file -> {
+					String presignedUrl = s3FileService.generatePresignedUrl(file.getFileUrl(), Duration.ofHours(1));
+					file.updateFileUrl(presignedUrl);
+				})
+		);
+
+		return NoticeResponseDto.fromNotices(notices);
+	}
+
+	// 6. 코스별 공지사항 조회 (추가된 메서드)
+	public List<NoticeResponseDto> getCourseNotices(Long courseId) {
+		List<Notice> notices = noticeRepository.findByCourseIdAndTypeOrderByCreatedAtDesc(courseId, NoticeType.COURSE);
+
+		// 각 공지사항의 파일들에 대해 Presigned URL 생성
+		notices.forEach(notice ->
+				notice.getFiles().forEach(file -> {
+					String presignedUrl = s3FileService.generatePresignedUrl(file.getFileUrl(), Duration.ofHours(1));
+					file.updateFileUrl(presignedUrl);
+				})
+		);
+
+		return NoticeResponseDto.fromNotices(notices);
+	}
+
+	// S3 URL에서 key 추출하는 유틸리티 메서드
+	private String extractKeyFromUrl(String fileUrl) {
+		String prefix = String.format("https://%s.s3.%s.amazonaws.com/",
+				awsS3Properties.getBucket(), awsS3Properties.getRegion());
+		return fileUrl.substring(prefix.length());
+	}
 }
+
+// 클로드 코드1
+//package com.example.epari.board.service;
+//
+//import com.example.epari.board.domain.Notice;
+//import com.example.epari.board.domain.NoticeFile;
+//import com.example.epari.board.dto.FileInfoDto;
+//import com.example.epari.board.dto.NoticeRequestDto;
+//import com.example.epari.board.dto.NoticeResponseDto;
+//import com.example.epari.board.repository.NoticeRepository;
+//import com.example.epari.board.repository.NoticeFileRepository;
+//import com.example.epari.course.domain.Course;
+//import com.example.epari.course.repository.CourseRepository;
+//import com.example.epari.global.common.enums.NoticeType;
+//import com.example.epari.global.common.service.S3FileService;
+//import com.example.epari.user.domain.Instructor;
+//import com.example.epari.user.repository.InstructorRepository;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//import jakarta.persistence.EntityNotFoundException;
+//import org.springframework.web.multipart.MultipartFile;
+//
+//import java.util.ArrayList;
+//import java.util.Collections;
+//import java.util.List;
+//
+//@Service
+//@Transactional(readOnly = true)
+//@RequiredArgsConstructor
+//
+//public class NoticeService {
+//	private final NoticeRepository noticeRepository;
+//	private final NoticeFileRepository noticeFileRepository;
+//	private final CourseRepository courseRepository;
+//	private final InstructorRepository instructorRepository;
+//	private final S3FileService s3FileService;  // FileService 대신 S3FileService 사용
+//
+//	@Transactional
+//	public Long createNotice(NoticeRequestDto requestDto) {
+//		Course course = courseRepository.findById(requestDto.getCourseId())
+//				.orElseThrow(() -> new EntityNotFoundException("Course not found"));
+//
+//		Instructor instructor = instructorRepository.findById(requestDto.getInstructorId())
+//				.orElseThrow(() -> new EntityNotFoundException("Instructor not found"));
+//
+//		Notice notice = noticeRepository.save(Notice.builder()
+//				.title(requestDto.getTitle())
+//				.content(requestDto.getContent())
+//				.type(requestDto.getType())
+//				.course(course)
+//				.instructor(instructor)
+//				.build());
+//
+//		// S3에 파일 업로드
+//		if (requestDto.getFiles() != null && !requestDto.getFiles().isEmpty()) {
+//			for (MultipartFile file : requestDto.getFiles()) {
+//				String fileUrl = s3FileService.uploadFile("notices", file);
+//				NoticeFile noticeFile = NoticeFile.createNoticeFile(
+//						file.getOriginalFilename(),
+//						extractKeyFromUrl(fileUrl),  // stored filename은 S3 key로 사용
+//						fileUrl,
+//						file.getSize(),
+//						notice
+//				);
+//				noticeFileRepository.save(noticeFile);
+//			}
+//		}
+//
+//		return notice.getId();
+//	}
+//
+//	@Transactional
+//	public Long updateNotice(Long id, NoticeRequestDto requestDto) {
+//		Notice notice = noticeRepository.findById(id)
+//				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
+//
+//		Course course = courseRepository.findById(requestDto.getCourseId())
+//				.orElseThrow(() -> new EntityNotFoundException("Course not found"));
+//
+//		// 삭제될 파일 처리
+//		if (requestDto.getDeleteFileIds() != null && !requestDto.getDeleteFileIds().isEmpty()) {
+//			for (Long fileId : requestDto.getDeleteFileIds()) {
+//				NoticeFile fileToDelete = notice.getFiles().stream()
+//						.filter(file -> file.getId().equals(fileId))
+//						.findFirst()
+//						.orElseThrow(() -> new EntityNotFoundException("File not found"));
+//
+//				// S3에서 파일 삭제
+//				s3FileService.deleteFile(fileToDelete.getFileUrl());
+//				notice.getFiles().remove(fileToDelete);
+//			}
+//		}
+//
+//		// 새로운 파일 추가
+//		if (requestDto.getFiles() != null && !requestDto.getFiles().isEmpty()) {
+//			for (MultipartFile file : requestDto.getFiles()) {
+//				String fileUrl = s3FileService.uploadFile("notices", file);
+//				NoticeFile noticeFile = NoticeFile.createNoticeFile(
+//						file.getOriginalFilename(),
+//						extractKeyFromUrl(fileUrl),
+//						fileUrl,
+//						file.getSize(),
+//						notice
+//				);
+//				notice.getFiles().add(noticeFile);
+//			}
+//		}
+//
+//		notice.update(
+//				requestDto.getTitle(),
+//				requestDto.getContent(),
+//				requestDto.getType(),
+//				course
+//		);
+//
+//		return notice.getId();
+//	}
+//
+//	@Transactional
+//	public void deleteNotice(Long noticeId) {
+//		Notice notice = noticeRepository.findById(noticeId)
+//				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
+//
+//		// S3에서 파일 삭제
+//		List<NoticeFile> files = noticeFileRepository.findByNoticeId(noticeId);
+//		files.forEach(file -> s3FileService.deleteFile(file.getFileUrl()));
+//
+//		noticeRepository.delete(notice);
+//	}
+//
+//	@Transactional
+//	public NoticeResponseDto getNotice(Long noticeId) {
+//		Notice notice = noticeRepository.findById(noticeId)
+//				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
+//
+//		notice.increaseViewCount();
+//
+//		// Presigned URL 생성
+//		notice.getFiles().forEach(file -> {
+//			String presignedUrl = s3FileService.generatePresignedUrl(file.getFileUrl(), Duration.ofHours(1));
+//			file.updateFileUrl(presignedUrl);
+//		});
+//
+//		List<Notice> singletonList = Collections.singletonList(notice);
+//		return NoticeResponseDto.fromNotices(singletonList).get(0);
+//	}
+//
+//	// S3 URL에서 key 추출
+//	private String extractKeyFromUrl(String fileUrl) {
+//		String prefix = String.format("https://%s.s3.%s.amazonaws.com/",
+//				awsS3Properties.getBucket(), awsS3Properties.getRegion());
+//		return fileUrl.substring(prefix.length());
+//	}
+//}
+
+
+// 원래 내코드
+//	private final NoticeRepository noticeRepository;
+//
+//	private final NoticeFileRepository noticeFileRepository;
+//
+//	private final CourseRepository courseRepository;
+//
+//	private final InstructorRepository instructorRepository;
+//
+//	private final FileService fileService;
+//
+//	private static final String UPLOAD_DIR = "C:/Users/MZC-USER/Desktop/pj";
+//
+//
+//
+//	@Transactional
+//	public Long createNotice(NoticeRequestDto requestDto) {
+//		Course course = courseRepository.findById(requestDto.getCourseId())
+//				.orElseThrow(() -> new EntityNotFoundException("Course not found"));
+//
+//		Instructor instructor = instructorRepository.findById(requestDto.getInstructorId())
+//				.orElseThrow(() -> new EntityNotFoundException("Instructor not found"));
+//
+//		Notice notice = noticeRepository.save(Notice.builder()
+//				.title(requestDto.getTitle())
+//				.content(requestDto.getContent())
+//				.type(requestDto.getType())
+//				.course(course)
+//				.instructor(instructor)
+//				.build());
+//
+//		// 파일 처리
+//		if (requestDto.getFiles() != null && !requestDto.getFiles().isEmpty()) {
+//			for (MultipartFile file : requestDto.getFiles()) {
+//				FileInfoDto fileInfo = fileService.uploadFile(file);
+//				NoticeFile noticeFile = NoticeFile.createNoticeFile(
+//						fileInfo.getOriginalFileName(),
+//						fileInfo.getStoredFileName(),
+//						fileInfo.getFileUrl(),
+//						fileInfo.getFileSize(),
+//						notice
+//				);
+//				noticeFileRepository.save(noticeFile);
+//			}
+//		}
+//
+//		return notice.getId();
+//	}
+//
+//	@Transactional
+//	public Long updateNotice(Long id, NoticeRequestDto requestDto) {
+//		Notice notice = noticeRepository.findById(id)
+//				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
+//
+//		Course course = courseRepository.findById(requestDto.getCourseId())
+//				.orElseThrow(() -> new EntityNotFoundException("Course not found"));
+//
+//		// 삭제될 파일 처리
+//		if (requestDto.getDeleteFileIds() != null && !requestDto.getDeleteFileIds().isEmpty()) {
+//			for (Long fileId : requestDto.getDeleteFileIds()) {
+//				NoticeFile fileToDelete = notice.getFiles().stream()
+//						.filter(file -> file.getId().equals(fileId))
+//						.findFirst()
+//						.orElseThrow(() -> new EntityNotFoundException("File not found"));
+//
+//				// 실제 파일 삭제
+//				fileService.deleteFile(fileToDelete.getStoredFileName());
+//				notice.getFiles().remove(fileToDelete);
+//			}
+//		}
+//
+//		// 새로운 파일 추가
+//		if (requestDto.getFiles() != null && !requestDto.getFiles().isEmpty()) {
+//			for (MultipartFile file : requestDto.getFiles()) {
+//				FileInfoDto fileInfo = fileService.uploadFile(file);
+//				NoticeFile noticeFile = NoticeFile.createNoticeFile(
+//						fileInfo.getOriginalFileName(),
+//						fileInfo.getStoredFileName(),
+//						fileInfo.getFileUrl(),
+//						fileInfo.getFileSize(),
+//						notice
+//				);
+//				notice.getFiles().add(noticeFile);
+//			}
+//		}
+//
+//		// 공지사항 정보 업데이트
+//		notice.update(
+//				requestDto.getTitle(),
+//				requestDto.getContent(),
+//				requestDto.getType(),
+//				course
+//		);
+//
+//		return notice.getId();
+//	}
+//
+//	@Transactional
+//	public void deleteNotice(Long noticeId) {
+//		Notice notice = noticeRepository.findById(noticeId)
+//				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
+//
+//		// 연관된 파일들 삭제
+//		List<NoticeFile> files = noticeFileRepository.findByNoticeId(noticeId);
+//		files.forEach(file -> fileService.deleteFile(file.getStoredFileName()));
+//
+//		noticeRepository.delete(notice);
+//	}
+//
+//	public List<NoticeResponseDto> getGlobalNotices() {
+//		List<Notice> notices = noticeRepository.findByTypeOrderByCreatedAtDesc(NoticeType.GLOBAL);
+//		return NoticeResponseDto.fromNotices(notices);
+//	}
+//
+//	public List<NoticeResponseDto> getCourseNotices(Long courseId) {
+//		List<Notice> notices = noticeRepository.findByCourseIdAndTypeOrderByCreatedAtDesc(courseId, NoticeType.COURSE);
+//		return NoticeResponseDto.fromNotices(notices);
+//	}
+//
+//	@Transactional
+//	public NoticeResponseDto getNotice(Long noticeId) {
+//		Notice notice = noticeRepository.findById(noticeId)
+//				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
+//
+//		notice.increaseViewCount();
+//
+//		List<Notice> singletonList = Collections.singletonList(notice);
+//		return NoticeResponseDto.fromNotices(singletonList).get(0);
+//	}
+//
+//}

--- a/src/main/java/com/example/epari/board/service/NoticeService.java
+++ b/src/main/java/com/example/epari/board/service/NoticeService.java
@@ -26,10 +26,15 @@ import java.util.List;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class NoticeService {
+
 	private final NoticeRepository noticeRepository;
+
 	private final NoticeFileRepository noticeFileRepository;
+
 	private final CourseRepository courseRepository;
+
 	private final InstructorRepository instructorRepository;
+
 	private final FileService fileService;
 
 	@Transactional
@@ -146,4 +151,5 @@ public class NoticeService {
 		List<Notice> singletonList = Collections.singletonList(notice);
 		return NoticeResponseDto.fromNotices(singletonList).get(0);
 	}
+
 }

--- a/src/main/java/com/example/epari/board/service/NoticeService.java
+++ b/src/main/java/com/example/epari/board/service/NoticeService.java
@@ -1,0 +1,98 @@
+// NoticeService.java
+package com.example.epari.board.service;
+
+import com.example.epari.board.domain.Notice;
+import com.example.epari.board.domain.NoticeFile;
+import com.example.epari.board.dto.NoticeRequestDto;
+import com.example.epari.board.dto.NoticeResponseDto;
+import com.example.epari.board.repository.NoticeRepository;
+import com.example.epari.board.repository.NoticeFileRepository;
+import com.example.epari.course.domain.Course;
+import com.example.epari.course.repository.CourseRepository;
+import com.example.epari.global.common.enums.NoticeType;
+import com.example.epari.user.domain.Instructor;
+import com.example.epari.user.repository.InstructorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class NoticeService {
+	private final NoticeRepository noticeRepository;
+	private final NoticeFileRepository noticeFileRepository;
+	private final CourseRepository courseRepository;
+	private final InstructorRepository instructorRepository;
+	private final FileService fileService;
+
+	@Transactional
+	public Long createNotice(NoticeRequestDto requestDto) {
+		Course course = courseRepository.findById(requestDto.getCourseId())
+				.orElseThrow(() -> new EntityNotFoundException("Course not found"));
+
+		Instructor instructor = instructorRepository.findById(requestDto.getInstructorId())
+				.orElseThrow(() -> new EntityNotFoundException("Instructor not found"));
+
+		Notice notice = noticeRepository.save(Notice.builder()
+				.title(requestDto.getTitle())
+				.content(requestDto.getContent())
+				.type(requestDto.getType())
+				.course(course)
+				.instructor(instructor)
+				.build());
+
+		if (requestDto.getFiles() != null && !requestDto.getFiles().isEmpty()) {
+			for (MultipartFile file : requestDto.getFiles()) {
+				String storedFileName = fileService.storeFile(file);
+				NoticeFile noticeFile = NoticeFile.createNoticeFile(
+						file.getOriginalFilename(),
+						storedFileName,
+						fileService.getFileUrl(storedFileName),
+						file.getSize(),
+						notice
+				);
+				noticeFileRepository.save(noticeFile);
+			}
+		}
+
+		return notice.getId();
+	}
+
+	@Transactional
+	public void deleteNotice(Long noticeId) {
+		Notice notice = noticeRepository.findById(noticeId)
+				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
+
+		List<NoticeFile> files = noticeFileRepository.findByNoticeId(noticeId);
+		files.forEach(file -> fileService.deleteFile(file.getStoredFileName()));
+
+		noticeRepository.delete(notice);
+	}
+
+	public List<NoticeResponseDto> getGlobalNotices() {
+		List<Notice> notices = noticeRepository.findByTypeOrderByCreatedAtDesc(NoticeType.GLOBAL);
+		return NoticeResponseDto.fromNotices(notices);
+	}
+
+	public List<NoticeResponseDto> getCourseNotices(Long courseId) {
+		List<Notice> notices = noticeRepository.findByCourseIdOrderByCreatedAtDesc(courseId);
+		return NoticeResponseDto.fromNotices(notices);
+	}
+
+	@Transactional
+	public NoticeResponseDto getNotice(Long noticeId) {
+		Notice notice = noticeRepository.findById(noticeId)
+				.orElseThrow(() -> new EntityNotFoundException("Notice not found"));
+
+		notice.increaseViewCount();
+
+		List<Notice> singletonList = Collections.singletonList(notice);
+		return NoticeResponseDto.fromNotices(singletonList).get(0);
+	}
+}


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- ex) Closes #이슈번호 -->
-  Closes #36 

## 변경 사항
<!-- 이 PR에서 변경된 주요 내용을 설명해주세요.
     변경사항이 여러 개일 경우, 주요 내용과 하위 항목을 구분하여 작성해주세요. -->
<!-- ex) 1. 000 엔티티 구현 -->
<!--        - 000 메서드 구현 -->


1. 공지사항 파일 업로드 기능 추가
    - 사용자가 파일을 업로드할 수 있습니다.
    - 업로드된 파일은 (로컬) 서버에 저장됩니다.
    - 

2. 공지사항  조회 기능
    - 업로드된 공지사항을 조회할 수 있도록 구현했습니다.
    - 사용자 요청에 따라 파일 정보를 제공하며, 상세 조회 API를 통해 확인 가능합니다.


3. 공지사항  삭제 기능
    - 특정 공지사항을 삭제하는 기능을 추가했습니다.
    - 삭제 시 서버 로컬에 저장된 파일도 함께 제거됩니다.


4. 공지사항  업데이트 기능
    - 기존에 업로드된 파일을 새로운 파일로 교체하거나 수정하는 기능을 추가했습니다.
    - 파일의 수정 사항이 반영될 수 있도록 처리하였습니다.


5. S3에 파일 저장 
    - API에서 파일을 업로드하면, S3에 파일 저장되도록 구현했습니다
    - 기존 로컬 서버에 파일이 저장되던 것을 S3에 저장되도록 수정했습니다.


공지사항은 전체 공지사항 & 강의 공지사항이 있는데, 
db구조로는 id를 같이 사용하고 있기 때문에,
각각 해당하는 공지사항만 출력하기 위해서 
NoticeResponseDto에 private Long displayNumber; 필드 추가했습니다.
// 화면에 보여줄 번호 (공지사항 타입 별로 따로 관리)




## 스크린샷
<!-- (선택) 주요 변경사항(기능 구현 화면, 테스트 결과 등)에 대한 이미지를 삽입해주세요. -->
<!-- 변경사항에 따라 아래 표 템플릿을 활용해주세요 -->


|기능|스크린샷|
|---|---|
|create|![스크린샷 2024-11-12 120033](https://github.com/user-attachments/assets/37a1efcf-dcae-4d36-8a63-a204bf3b334f)|


|기능|스크린샷|
|---|---|
|read|![스크린샷 2024-11-12 122106](https://github.com/user-attachments/assets/6ea9cbe1-665e-4bf8-8443-bb75e90964aa)|


|기능|스크린샷|
|---|---|
|update|![image](https://github.com/user-attachments/assets/bf465993-ac1b-4a19-ac6b-099c30d2be0e)|


|기능|스크린샷|
|---|---|
|delete|![image](https://github.com/user-attachments/assets/84b61e5f-054e-4bda-90b9-053c0b113059)|


|기능|스크린샷|
|---|---|
|S3에 저장|![image](https://github.com/user-attachments/assets/fc5afcad-e371-4dd5-b178-37f3f199ba9d)|



## 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항들입니다. -->
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [ ] 관련 문서를 업데이트하였습니까?

## 공유사항

<!-- 리뷰어에게 전달할 추가 정보가 있다면 여기에 적어주세요. -->


## 추후 업무
<!-- 추후 진행될 과제에 대해 적어주세요. -->
<!-- ex) [ ] 000 기능 구현 -->
- [ ] 프론트엔드와 연동 구현
