### PR TITLE
[FEAT] 당일 자료 강의 자료 조회 구현

### DIFF
--- a/src/main/java/com/example/epari/course/controller/CourseContentController.java
+++ b/src/main/java/com/example/epari/course/controller/CourseContentController.java
@@ -136,4 +136,13 @@ public class CourseContentController {
 		return ResponseEntity.ok(courseContentService.deleteFile(courseId, contentId, fileId));
 	}
 
+	/**
+	 * 당일 날짜의 강의 자료를 조회합니다.
+	 */
+	@GetMapping("/today")
+	public ResponseEntity<List<CourseContentResponseDto>> getTodayContents(
+			@PathVariable Long courseId) {
+		return ResponseEntity.ok(courseContentService.getTodayContents(courseId));
+	}
+
 }

--- a/src/main/java/com/example/epari/course/service/CourseContentService.java
+++ b/src/main/java/com/example/epari/course/service/CourseContentService.java
@@ -1,6 +1,7 @@
 package com.example.epari.course.service;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -178,6 +179,16 @@ public class CourseContentService {
 		content.removeFile(file);
 
 		return CourseContentResponseDto.from(content);
+	}
+
+	/**
+	 * 당일 날짜의 강의 자료를 조회합니다.
+	 */
+	public List<CourseContentResponseDto> getTodayContents(Long courseId) {
+		LocalDate today = LocalDate.now();
+		return courseContentRepository.findByCourseIdAndDate(courseId, today).stream()
+				.map(CourseContentResponseDto::from)
+				.toList();
 	}
 
 	private String extractStoredFileName(String fileUrl) {

--- a/src/main/java/com/example/epari/course/service/CourseContentService.java
+++ b/src/main/java/com/example/epari/course/service/CourseContentService.java
@@ -183,6 +183,7 @@ public class CourseContentService {
 
 	/**
 	 * 당일 날짜의 강의 자료를 조회합니다.
+	 * TODO: 단위 테스트 코드 여기로 작성해보기!!
 	 */
 	public List<CourseContentResponseDto> getTodayContents(Long courseId) {
 		LocalDate today = LocalDate.now();


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- ex) Closes #이슈번호 -->
- #57 

## 변경 사항
<!-- 이 PR에서 변경된 주요 내용을 설명해주세요.
     변경사항이 여러 개일 경우, 주요 내용과 하위 항목을 구분하여 작성해주세요. -->
<!-- ex) 1. 000 엔티티 구현 -->
<!--        - 000 메서드 구현 -->
1. 강의 자료 당일 조회 기능 구현
  - CourseContentController에 /api/courses/{courseId}/contents/today GET 엔드포인트 추가 
  - CourseContentService에 getTodayContents 메서드 구현
  - 당일 날짜 기준 강의 자료 필터링 로직 추가
2. 서비스 로직 구현 세부사항
  - LocalDate.now()를 사용하여 현재 날짜 기준 조회
  - Stream API를 사용하여 DTO 변환 처리

## 스크린샷
<!-- (선택) 주요 변경사항(기능 구현 화면, 테스트 결과 등)에 대한 이미지를 삽입해주세요. -->
<!-- 변경사항에 따라 아래 표 템플릿을 활용해주세요 -->

|기능|스크린샷|
|---|---|
|당일 강의 자료 조회|<img width="716" alt="image" src="https://github.com/user-attachments/assets/22fbbad3-11ba-4840-afd2-a95d7b4b6747">|

## 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항들입니다. -->
- [ x ] 코드 컨벤션을 준수하였습니까?
- [ x ] 모든 테스트를 통과하였습니까?
- [ x ] 관련 문서를 업데이트하였습니까?

## 공유사항
- 당일 기준을 다른 날로 변경하여 테스트 할 경우 LocalDate today = LocalDate.of(2024,11,12); 로 테스트  