### PR TITLE
[FEAT] 글로벌 예외 처리 및 에러 응답 규격화 구현

### DIFF
--- a/src/main/java/com/example/epari/course/service/AttendanceService.java
+++ b/src/main/java/com/example/epari/course/service/AttendanceService.java
@@ -13,7 +13,6 @@ import com.example.epari.course.domain.CourseStudent;
 import com.example.epari.course.dto.attendance.AttendanceResponseDto;
 import com.example.epari.course.dto.attendance.AttendanceUpdateDto;
 import com.example.epari.course.repository.AttendanceRepository;
-import com.example.epari.course.repository.CourseRepository;
 import com.example.epari.course.repository.CourseStudentRepository;
 import com.example.epari.global.validator.CourseAccessValidator;
 
@@ -29,8 +28,6 @@ public class AttendanceService {
 
 	private final AttendanceRepository attendanceRepository;
 
-	private final CourseRepository courseRepository;
-
 	private final CourseStudentRepository courseStudentRepository;
 
 	private final CourseAccessValidator courseAccessValidator;
@@ -41,7 +38,6 @@ public class AttendanceService {
 	 */
 	@Transactional
 	public List<AttendanceResponseDto> getAttendances(Long courseId, String instructorEmail, LocalDate date) {
-
 		courseAccessValidator.validateInstructorAccess(courseId, instructorEmail);
 
 		List<Attendance> attendances = attendanceRepository.findAllByCourseIdAndDate(courseId, date);

--- a/src/main/java/com/example/epari/global/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/epari/global/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package com.example.epari.global.config.security;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.example.epari.global.exception.ErrorCode;
+import com.example.epari.global.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+	private static final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+			AccessDeniedException accessDeniedException) throws IOException {
+
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.FORBIDDEN);
+
+		response.setStatus(HttpStatus.FORBIDDEN.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		objectMapper.writeValue(response.getWriter(), errorResponse);
+	}
+
+}

--- a/src/main/java/com/example/epari/global/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/epari/global/config/security/CustomAccessDeniedHandler.java
@@ -15,11 +15,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+/**
+ * 접근 거부(403) 예외 발생 시 처리를 담당하는 핸들러
+ * 권한이 없는 리소스에 접근 시도 시 JSON 형식의 에러 응답을 반환
+ */
 @Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
 	private static final ObjectMapper objectMapper = new ObjectMapper();
 
+	/**
+	 * 접근 거부 예외 발생 시 클라이언트에게 JSON 형식의 에러 응답을 반환
+	 */
 	@Override
 	public void handle(HttpServletRequest request, HttpServletResponse response,
 			AccessDeniedException accessDeniedException) throws IOException {

--- a/src/main/java/com/example/epari/global/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/epari/global/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.example.epari.global.config.security;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.example.epari.global.exception.ErrorCode;
+import com.example.epari.global.exception.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private static final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException authException) throws IOException {
+
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.UNAUTHORIZED);
+
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		objectMapper.writeValue(response.getWriter(), errorResponse);
+	}
+
+}

--- a/src/main/java/com/example/epari/global/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/epari/global/config/security/CustomAuthenticationEntryPoint.java
@@ -15,11 +15,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+/**
+ * 인증되지 않은 요청(401) 발생 시 처리를 담당하는 핸들러
+ * 인증이 필요한 리소스에 인증 없이 접근 시도 시 JSON 형식의 에러 응답을 반환
+ */
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
 	private static final ObjectMapper objectMapper = new ObjectMapper();
 
+	/**
+	 * 인증 실패 시 클라이언트에게 JSON 형식의 에러 응답을 반환
+	 */
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
 			AuthenticationException authException) throws IOException {

--- a/src/main/java/com/example/epari/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/epari/global/config/security/SecurityConfig.java
@@ -35,6 +35,10 @@ public class SecurityConfig {
 
 	private final CorsProperties corsProperties;
 
+	private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+	private final CustomAccessDeniedHandler accessDeniedHandler;
+
 	@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
 	private String issuerUri;
 
@@ -56,6 +60,10 @@ public class SecurityConfig {
 						.jwt(jwt -> jwt
 								.jwtAuthenticationConverter(jwtAuthenticationConverter())
 						)
+				)
+				.exceptionHandling(handling -> handling
+						.authenticationEntryPoint(authenticationEntryPoint)
+						.accessDeniedHandler(accessDeniedHandler)
 				);
 
 		return http.build();

--- a/src/main/java/com/example/epari/global/exception/BusinessBaseException.java
+++ b/src/main/java/com/example/epari/global/exception/BusinessBaseException.java
@@ -1,0 +1,15 @@
+package com.example.epari.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessBaseException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public BusinessBaseException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+}

--- a/src/main/java/com/example/epari/global/exception/BusinessBaseException.java
+++ b/src/main/java/com/example/epari/global/exception/BusinessBaseException.java
@@ -2,6 +2,10 @@ package com.example.epari.global.exception;
 
 import lombok.Getter;
 
+/**
+ * 애플리케이션의 모든 비즈니스 예외의 기본 클래스
+ * 구체적인 비즈니스 예외들은 이 클래스를 상속받아 구현
+ */
 @Getter
 public class BusinessBaseException extends RuntimeException {
 

--- a/src/main/java/com/example/epari/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorCode.java
@@ -1,0 +1,41 @@
+package com.example.epari.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+	// 공통 에러 코드 (Common: CMM)
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "CMM-001", "잘못된 요청입니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CMM-002", "서버 내부에서 오류가 발생했습니다."),
+	NOT_FOUND(HttpStatus.NOT_FOUND, "CMM-003", "요청한 리소스를 찾을 수 없습니다."),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "CMM-004", "해당 리소스에 대한 접근 권한이 없습니다."),
+	INVALID_INPUT(HttpStatus.BAD_REQUEST, "CMM-005", "입력값이 올바르지 않습니다."),
+
+	// Course 관련 에러 코드 (CRS)
+	COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "CRS-001", "강의를 찾을 수 없습니다."),
+	UNAUTHORIZED_COURSE_ACCESS(HttpStatus.FORBIDDEN, "CRS-002", "해당 강의에 대한 접근 권한이 없습니다."),
+
+	// Assignment 관련 에러 코드 (ASM)
+	ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ASM-001", "과제를 찾을 수 없습니다."),
+	SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "ASM-002", "과제 제출물을 찾을 수 없습니다."),
+
+	// Exam 관련 에러 코드 (EXAM)
+	EXAM_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM-001", "시험을 찾을 수 없습니다."),
+	EXAM_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM-002", "시험 결과를 찾을 수 없습니다.");
+
+	private final HttpStatus status;
+
+	private final String code;
+
+	private final String message;
+
+	ErrorCode(HttpStatus status, String code, String message) {
+		this.status = status;
+		this.code = code;
+		this.message = message;
+	}
+
+}

--- a/src/main/java/com/example/epari/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorCode.java
@@ -4,6 +4,10 @@ import org.springframework.http.HttpStatus;
 
 import lombok.Getter;
 
+/**
+ * 애플리케이션에서 사용하는 모든 에러 코드를 정의하는 열거형
+ * 각 에러의 HTTP 상태 코드, 비즈니스 코드 및 메시지를 포함
+ */
 @Getter
 public enum ErrorCode {
 

--- a/src/main/java/com/example/epari/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorCode.java
@@ -11,8 +11,11 @@ public enum ErrorCode {
 	BAD_REQUEST(HttpStatus.BAD_REQUEST, "CMM-001", "잘못된 요청입니다."),
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CMM-002", "서버 내부에서 오류가 발생했습니다."),
 	NOT_FOUND(HttpStatus.NOT_FOUND, "CMM-003", "요청한 리소스를 찾을 수 없습니다."),
-	FORBIDDEN(HttpStatus.FORBIDDEN, "CMM-004", "해당 리소스에 대한 접근 권한이 없습니다."),
-	INVALID_INPUT(HttpStatus.BAD_REQUEST, "CMM-005", "입력값이 올바르지 않습니다."),
+	INVALID_INPUT(HttpStatus.BAD_REQUEST, "CMM-004", "입력값이 올바르지 않습니다."),
+
+	// 인증, 인가 관련 에러 코드 (AUTH)
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH-001", "인증이 필요한 요청입니다."),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH-002", "해당 리소스에 대한 접근 권한이 없습니다."),
 
 	// Course 관련 에러 코드 (CRS)
 	COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "CRS-001", "강의를 찾을 수 없습니다."),

--- a/src/main/java/com/example/epari/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorResponse.java
@@ -1,0 +1,21 @@
+package com.example.epari.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+	private final String message;
+
+	private final String code;
+
+	private ErrorResponse(ErrorCode errorCode) {
+		this.message = errorCode.getMessage();
+		this.code = errorCode.getCode();
+	}
+
+	public static ErrorResponse of(ErrorCode errorCode) {
+		return new ErrorResponse(errorCode);
+	}
+
+}

--- a/src/main/java/com/example/epari/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorResponse.java
@@ -5,6 +5,10 @@ import java.util.List;
 
 import lombok.Getter;
 
+/**
+ * API 에러 응답의 표준 형식을 정의하는 클래스
+ * 에러 메시지, 코드 및 상세 검증 오류 목록을 포함
+ */
 @Getter
 public class ErrorResponse {
 

--- a/src/main/java/com/example/epari/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorResponse.java
@@ -1,5 +1,8 @@
 package com.example.epari.global.exception;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import lombok.Getter;
 
 @Getter
@@ -9,13 +12,26 @@ public class ErrorResponse {
 
 	private final String code;
 
+	private final List<ValidationError> errors;
+
 	private ErrorResponse(ErrorCode errorCode) {
 		this.message = errorCode.getMessage();
 		this.code = errorCode.getCode();
+		this.errors = new ArrayList<>();
+	}
+
+	private ErrorResponse(ErrorCode errorCode, List<ValidationError> errors) {
+		this.message = errorCode.getMessage();
+		this.code = errorCode.getCode();
+		this.errors = errors;
 	}
 
 	public static ErrorResponse of(ErrorCode errorCode) {
 		return new ErrorResponse(errorCode);
+	}
+
+	public static ErrorResponse of(ErrorCode errorCode, List<ValidationError> errors) {
+		return new ErrorResponse(errorCode, errors);
 	}
 
 }

--- a/src/main/java/com/example/epari/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/epari/global/exception/GlobalExceptionHandler.java
@@ -14,10 +14,18 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * 애플리케이션 전역의 예외 처리를 담당하는 핸들러
+ * 발생하는 모든 예외를 적절한 형식의 응답으로 변환하여 클라이언트에게 반환
+ */
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+	/**
+	 * 비즈니스 예외 처리
+	 * BusinessBaseException과 그 하위 예외들을 처리하여 적절한 에러 응답을 생성
+	 */
 	@ExceptionHandler(BusinessBaseException.class)
 	protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessBaseException e) {
 		log.error("Business exception occurred: {}", e.getMessage(), e);
@@ -26,6 +34,10 @@ public class GlobalExceptionHandler {
 				.body(errorResponse);
 	}
 
+	/**
+	 * 입력값 검증 실패 예외 처리
+	 * @Valid 어노테이션으로 검증 실패 시 발생하는 예외를 처리
+	 */
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
 		List<ValidationError> validationErrors = ex.getBindingResult()
@@ -42,6 +54,9 @@ public class GlobalExceptionHandler {
 				.body(errorResponse);
 	}
 
+	/**
+	 * 요청한 리소스를 찾을 수 없을 때 발생하는 예외 처리
+	 */
 	@ExceptionHandler(NoResourceFoundException.class)
 	protected ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException e) {
 		log.warn("Resource not found: {}", e.getMessage());
@@ -50,6 +65,9 @@ public class GlobalExceptionHandler {
 				.body(errorResponse);
 	}
 
+	/**
+	 * 지원하지 않는 HTTP 메서드 호출 시 발생하는 예외 처리
+	 */
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
 	protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupported(
 			HttpRequestMethodNotSupportedException e) {
@@ -59,6 +77,10 @@ public class GlobalExceptionHandler {
 				.body(errorResponse);
 	}
 
+	/**
+	 * HTTP 요청 메시지를 읽을 수 없을 때 발생하는 예외 처리
+	 * 주로 잘못된 JSON 형식이나 타입 불일치로 인해 발생
+	 */
 	@ExceptionHandler(HttpMessageNotReadableException.class)
 	protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(
 			HttpMessageNotReadableException e) {
@@ -68,6 +90,9 @@ public class GlobalExceptionHandler {
 				.body(errorResponse);
 	}
 
+	/**
+	 * 필수 요청 파라미터가 누락되었을 때 발생하는 예외 처리
+	 */
 	@ExceptionHandler(MissingServletRequestParameterException.class)
 	protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameter(
 			MissingServletRequestParameterException e) {
@@ -77,6 +102,10 @@ public class GlobalExceptionHandler {
 				.body(errorResponse);
 	}
 
+	/**
+	 * 위의 핸들러들에서 처리되지 않은 모든 예외를 처리하는 fallback 핸들러
+	 * 예상치 못한 서버 오류를 처리
+	 */
 	@ExceptionHandler(Exception.class)
 	protected ResponseEntity<ErrorResponse> handleException(Exception e) {
 		log.error("Unhandled exception occurred", e);

--- a/src/main/java/com/example/epari/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/epari/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,90 @@
+package com.example.epari.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(BusinessBaseException.class)
+	protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessBaseException e) {
+		log.error("Business exception occurred: {}", e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode());
+		return ResponseEntity.status(e.getErrorCode().getStatus())
+				.body(errorResponse);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+		BindingResult result = ex.getBindingResult();
+		StringBuilder errorMessage = new StringBuilder();
+
+		for (FieldError fieldError : result.getFieldErrors()) {
+			errorMessage.append(fieldError.getField())
+					.append(": ")
+					.append(fieldError.getDefaultMessage())
+					.append(", ");
+		}
+
+		log.warn("Validation failed: {}", errorMessage);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT);
+		return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus())
+				.body(errorResponse);
+	}
+
+	@ExceptionHandler(NoResourceFoundException.class)
+	protected ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException e) {
+		log.warn("Resource not found: {}", e.getMessage());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND);
+		return ResponseEntity.status(ErrorCode.NOT_FOUND.getStatus())
+				.body(errorResponse);
+	}
+
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupported(
+			HttpRequestMethodNotSupportedException e) {
+		log.warn("Method not supported: {}", e.getMessage());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.BAD_REQUEST);
+		return ResponseEntity.status(ErrorCode.BAD_REQUEST.getStatus())
+				.body(errorResponse);
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadable(
+			HttpMessageNotReadableException e) {
+		log.warn("Message not readable: {}", e.getMessage());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT);
+		return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus())
+				.body(errorResponse);
+	}
+
+	@ExceptionHandler(MissingServletRequestParameterException.class)
+	protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameter(
+			MissingServletRequestParameterException e) {
+		log.warn("Missing parameter: {}", e.getMessage());
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT);
+		return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus())
+				.body(errorResponse);
+	}
+
+	@ExceptionHandler(Exception.class)
+	protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+		log.error("Unhandled exception occurred", e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+		return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+				.body(errorResponse);
+	}
+
+}

--- a/src/main/java/com/example/epari/global/exception/ValidationError.java
+++ b/src/main/java/com/example/epari/global/exception/ValidationError.java
@@ -2,6 +2,10 @@ package com.example.epari.global.exception;
 
 import lombok.Getter;
 
+/**
+ * 입력값 검증 실패 시 발생하는 오류 정보를 담는 클래스
+ * 필드명과 해당 필드의 유효성 검증 실패 메시지를 포함
+ */
 @Getter
 public class ValidationError {
 

--- a/src/main/java/com/example/epari/global/exception/ValidationError.java
+++ b/src/main/java/com/example/epari/global/exception/ValidationError.java
@@ -1,0 +1,21 @@
+package com.example.epari.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ValidationError {
+
+	private final String field;
+
+	private final String message;
+
+	private ValidationError(String field, String message) {
+		this.field = field;
+		this.message = message;
+	}
+
+	public static ValidationError of(String field, String message) {
+		return new ValidationError(field, message);
+	}
+
+}

--- a/src/main/java/com/example/epari/global/exception/course/CourseAccessDeniedException.java
+++ b/src/main/java/com/example/epari/global/exception/course/CourseAccessDeniedException.java
@@ -3,6 +3,9 @@ package com.example.epari.global.exception.course;
 import com.example.epari.global.exception.BusinessBaseException;
 import com.example.epari.global.exception.ErrorCode;
 
+/**
+ * 강의에 대한 접근 권한이 없는 경우 발생하는 예외
+ */
 public class CourseAccessDeniedException extends BusinessBaseException {
 
 	public CourseAccessDeniedException() {

--- a/src/main/java/com/example/epari/global/exception/course/CourseAccessDeniedException.java
+++ b/src/main/java/com/example/epari/global/exception/course/CourseAccessDeniedException.java
@@ -1,0 +1,12 @@
+package com.example.epari.global.exception.course;
+
+import com.example.epari.global.exception.BusinessBaseException;
+import com.example.epari.global.exception.ErrorCode;
+
+public class CourseAccessDeniedException extends BusinessBaseException {
+
+	public CourseAccessDeniedException() {
+		super(ErrorCode.UNAUTHORIZED_COURSE_ACCESS);
+	}
+
+}

--- a/src/main/java/com/example/epari/global/validator/CourseAccessValidator.java
+++ b/src/main/java/com/example/epari/global/validator/CourseAccessValidator.java
@@ -3,6 +3,7 @@ package com.example.epari.global.validator;
 import org.springframework.stereotype.Component;
 
 import com.example.epari.course.repository.CourseRepository;
+import com.example.epari.global.exception.course.CourseAccessDeniedException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,14 +19,14 @@ public class CourseAccessValidator {
 	// 강사의 강의 접근권한 검증
 	public void validateInstructorAccess(Long courseId, String instructorEmail) {
 		if (!courseRepository.existsByCourseIdAndInstructorEmail(courseId, instructorEmail)) {
-			throw new IllegalArgumentException("해당 강의에 대한 접근 권한이 없습니다.");
+			throw new CourseAccessDeniedException();
 		}
 	}
 
 	// 학생의 강의 접근권한 검증
 	public void validateStudentAccess(Long courseId, String studentEmail) {
 		if (!courseRepository.existsByCourseIdAndStudentEmail(courseId, studentEmail)) {
-			throw new IllegalArgumentException("해당 강의에 대한 접근 권한이 없습니다.");
+			throw new CourseAccessDeniedException();
 		}
 	}
 


### PR DESCRIPTION
## 관련 이슈
- Closes #56 

## 변경 사항
1. 에러 코드 정의
   - 공통 에러 코드 정의 (BAD_REQUEST, INTERNAL_SERVER_ERROR 등)
   - 도메인별 에러 코드 정의 (강의, 과제, 시험)

2. 비즈니스 예외 처리 아키텍처 구현
   - `BusinessBaseException` 클래스 구현
   - `ErrorResponse` DTO 구현
   - `ValidationError` 클래스 추가
   - `GlobalExceptionHandler` 구현

3. Spring Security 예외 처리 구현
   - `CustomAuthenticationEntryPoint` 구현
   - `CustomAccessDeniedHandler` 구현
   - `SecurityConfig` 설정 추가

4. 도메인별 접근 제어 예외 구현
   - `CourseAccessDeniedException` 추가
   - `CourseAccessValidator` 리팩토링

## 스크린샷
|기능|스크린샷|
|---|---|
|CourseAccessDeniedException 발생 시 응답|![image](https://github.com/user-attachments/assets/f52bf48d-86bf-4069-a620-9b197f9b311f)|

## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- 모든 비즈니스 예외는 `BusinessBaseException`을 상속받아 구현했습니다
- 예외 발생 시 로그 레벨을 다음과 같이 구분했습니다:
  - ERROR: 시스템 예외
  - WARN: 비즈니스 예외
  - INFO: 인증/인가 예외

## 추후 업무