### PR TITLE
[FEAT] 커리큘럼 조회 엔드포인트 구현

### DIFF
--- a/src/main/java/com/example/epari/course/controller/CurriculumController.java
+++ b/src/main/java/com/example/epari/course/controller/CurriculumController.java
@@ -1,0 +1,33 @@
+package com.example.epari.course.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.epari.course.dto.curriculum.CurriculumResponseDto;
+import com.example.epari.course.service.CurriculumService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 커리큘럼 관련 엔드포인트를 처리하는 컨트롤러 클래스
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/courses/{courseId}")
+public class CurriculumController {
+
+	private final CurriculumService curriculumService;
+
+	/**
+	 * 특정 강의 커리큘럼 조회
+	 */
+	@GetMapping("/curriculums")
+	public List<CurriculumResponseDto> getCurriculums(@PathVariable("courseId") Long courseId) {
+		return curriculumService.getCurriculumsByCourseId(courseId);
+	}
+
+}

--- a/src/main/java/com/example/epari/course/dto/curriculum/CurriculumResponseDto.java
+++ b/src/main/java/com/example/epari/course/dto/curriculum/CurriculumResponseDto.java
@@ -1,0 +1,34 @@
+package com.example.epari.course.dto.curriculum;
+
+import java.time.LocalDate;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 커리큘럼 응답 정보를 담는 DTO 클래스 
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CurriculumResponseDto {
+
+	private LocalDate date;
+
+	private String topic;
+
+	private String description;
+
+	@Builder
+	public CurriculumResponseDto(
+			LocalDate date,
+			String topic,
+			String description
+	) {
+		this.date = date;
+		this.topic = topic;
+		this.description = description;
+	}
+
+}

--- a/src/main/java/com/example/epari/course/dto/curriculum/curriculumReponseDto.java
+++ b/src/main/java/com/example/epari/course/dto/curriculum/curriculumReponseDto.java
@@ -1,5 +1,0 @@
-package com.example.epari.course.dto.curriculum;
-
-public class curriculumReponseDto {
-
-}

--- a/src/main/java/com/example/epari/course/dto/curriculum/curriculumRequestDto.java
+++ b/src/main/java/com/example/epari/course/dto/curriculum/curriculumRequestDto.java
@@ -1,5 +1,0 @@
-package com.example.epari.course.dto.curriculum;
-
-public class curriculumRequestDto {
-
-}

--- a/src/main/java/com/example/epari/course/repository/CurriculumRepository.java
+++ b/src/main/java/com/example/epari/course/repository/CurriculumRepository.java
@@ -1,9 +1,29 @@
 package com.example.epari.course.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.epari.course.domain.Curriculum;
+import com.example.epari.course.dto.curriculum.CurriculumResponseDto;
 
+/**
+ * 커리큘럼 정보에 대한 데이터베이스 접근을 담당하는 레포지토리 인터페이스
+ */
 public interface CurriculumRepository extends JpaRepository<Curriculum, Long> {
+
+	@Query("""
+					SELECT new com.example.epari.course.dto.curriculum.CurriculumResponseDto(
+						c.date,
+						c.topic,
+						c.description
+					)
+					FROM Curriculum c
+					WHERE c.course.id = :courseId
+					order by c.date asc
+			""")
+	List<CurriculumResponseDto> findAllByCourseId(@Param("courseId") Long courseId);
 
 }

--- a/src/main/java/com/example/epari/course/service/CurriculumService.java
+++ b/src/main/java/com/example/epari/course/service/CurriculumService.java
@@ -1,0 +1,30 @@
+package com.example.epari.course.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.epari.course.dto.curriculum.CurriculumResponseDto;
+import com.example.epari.course.repository.CurriculumRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 커리큘럼 관련 비즈니스 로직을 처리하는 서비스 클래스
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CurriculumService {
+
+	private final CurriculumRepository curriculumRepository;
+
+	/**
+	 * 특정 강의 커리큘럼 조회
+	 */
+	public List<CurriculumResponseDto> getCurriculumsByCourseId(Long courseId) {
+		return curriculumRepository.findAllByCourseId(courseId);
+	}
+
+}


### PR DESCRIPTION
## 관련 이슈
- Closes #64 

## 변경 사항
1. 커리큘럼 DTO 구현
   - 날짜, 주제, 설명 정보를 포함하는 응답 구조 설계
   - 불필요한 DTO 클래스 제거로 코드 정리

2. 커리큘럼 조회 기능 구현
   - JPQL을 활용한 최적화된 쿼리 구현
   - DTO 직접 조회 방식으로 성능 개선
   - 날짜 기준 오름차순 정렬 적용

3. 서비스 계층 구현
   - 커리큘럼 조회 비즈니스 로직 구현
   - Repository 계층과의 연동

4. API 엔드포인트 구현
   - Course ID 기반 커리큘럼 조회 REST API
   - 명확한 응답 구조 정의

## 스크린샷
|기능|스크린샷|
|---|---|
|API 응답 예시|![image](https://github.com/user-attachments/assets/133f65a2-f587-40b4-9b3d-c615df2caeda)|

## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- DTO 직접 조회 방식을 통해 N+1 문제를 방지했습니다.
- 날짜 기준 정렬을 통해 프론트엔드에서의 추가 정렬 작업이 필요 없도록 했습니다.
- API 응답은 프론트엔드의 FullCalendar 컴포넌트 형식에 맞게 구조화했습니다.

## 추후 업무
- [ ] 커리큘럼 수정 API 구현