### PR TITLE
[FEAT] Cognito 연동 및 관리자 승인 프로세스

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ src/main/resources/application-dev.yaml
 
 ### Test Profile ###
 src/test/resources/application-test.properties
+src/test/resources/application-test.yaml

--- a/src/main/java/com/example/epari/admin/controller/AdminCourseController.java
+++ b/src/main/java/com/example/epari/admin/controller/AdminCourseController.java
@@ -1,0 +1,36 @@
+package com.example.epari.admin.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.epari.admin.dto.CourseSearchResponseDTO;
+import com.example.epari.admin.service.AdminCourseService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 관리자를 위한 REST API 컨트롤러
+ * 강의 관리
+ */
+@RestController
+@RequestMapping("/api/admin/courses")
+@RequiredArgsConstructor
+public class AdminCourseController {
+
+	private final AdminCourseService adminCourseService;
+
+	/**
+	 * keyword 기반 강의 목록 검색 엔드포인트
+	 */
+	@GetMapping("/search")
+	public ResponseEntity<List<CourseSearchResponseDTO>> searchCourses(
+			@RequestParam(required = false) String keyword) {
+		return ResponseEntity.ok(adminCourseService.searchCourses(keyword));
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/controller/AdminUserManagementController.java
+++ b/src/main/java/com/example/epari/admin/controller/AdminUserManagementController.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * 관리자를 위한 REST API 컨트롤러
+ * 사용자 관리
  */
 @RestController
 @RequestMapping("/api/admin/users")
@@ -55,7 +56,7 @@ public class AdminUserManagementController {
 		adminUserService.approveUser(email, request);
 
 		// 2. Cognito 그룹 변경
-		cognitoService.changeUserGroup(email, "STUDENT");
+		cognitoService.changeUserGroup(request.getUsername(), "STUDENT");
 
 		// 3. TODO 이메일 발송
 

--- a/src/main/java/com/example/epari/admin/controller/AdminUserManagementController.java
+++ b/src/main/java/com/example/epari/admin/controller/AdminUserManagementController.java
@@ -4,10 +4,15 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.epari.admin.dto.ApprovalRequestDTO;
 import com.example.epari.admin.dto.CognitoUserDTO;
+import com.example.epari.admin.service.AdminUserService;
 import com.example.epari.admin.service.CognitoService;
 
 import lombok.RequiredArgsConstructor;
@@ -24,6 +29,8 @@ public class AdminUserManagementController {
 
 	private final CognitoService cognitoService;
 
+	private final AdminUserService adminUserService;
+
 	/**
 	 * 임시 그룹에 속한 사용자를 조회하는 엔드포인트
 	 */
@@ -33,6 +40,39 @@ public class AdminUserManagementController {
 				cognitoService.getUsersByGroup("PENDING_ROLES");
 
 		return ResponseEntity.ok(pendingUsers);
+	}
+
+	/**
+	 * 임시 그룹에 속한 사용자를 승인하는 엔드포인트
+	 * 특정 강의와의 매핑 작업을 수행
+	 */
+	@PostMapping("/{userEmail}/approve")
+	public ResponseEntity<Void> approveUser(
+			@PathVariable("userEmail") String email,
+			@RequestBody ApprovalRequestDTO request
+	) {
+		// 1. 백엔드 DB에 승인 상태 업데이트
+		adminUserService.approveUser(email, request);
+
+		// 2. Cognito 그룹 변경
+		cognitoService.changeUserGroup(email, "STUDENT");
+
+		// 3. TODO 이메일 발송
+
+		return ResponseEntity.ok().build();
+	}
+
+	/**
+	 * 임시 그룹에 속한 사용자를 반려하는 엔드포인트
+	 */
+	@PostMapping("/{userEmail}/reject")
+	public ResponseEntity<Void> rejectUser(@PathVariable("userEmail") String email) {
+		// 1. Cognito에서 사용자 삭제
+		cognitoService.deleteUser(email);
+
+		// 2. TODO 이메일 발송
+
+		return ResponseEntity.ok().build();
 	}
 
 }

--- a/src/main/java/com/example/epari/admin/controller/AdminUserManagementController.java
+++ b/src/main/java/com/example/epari/admin/controller/AdminUserManagementController.java
@@ -1,0 +1,38 @@
+package com.example.epari.admin.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.epari.admin.dto.CognitoUserDTO;
+import com.example.epari.admin.service.CognitoService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 관리자를 위한 REST API 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/admin/users")
+@RequiredArgsConstructor
+@Slf4j
+public class AdminUserManagementController {
+
+	private final CognitoService cognitoService;
+
+	/**
+	 * 임시 그룹에 속한 사용자를 조회하는 엔드포인트
+	 */
+	@GetMapping("/pending")
+	public ResponseEntity<List<CognitoUserDTO>> getPendingUsers() {
+		List<CognitoUserDTO> pendingUsers =
+				cognitoService.getUsersByGroup("PENDING_ROLES");
+
+		return ResponseEntity.ok(pendingUsers);
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/dto/ApprovalRequestDTO.java
+++ b/src/main/java/com/example/epari/admin/dto/ApprovalRequestDTO.java
@@ -1,0 +1,19 @@
+package com.example.epari.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자 승인 요청 DTO
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApprovalRequestDTO {
+
+	private Long courseId;
+
+	private String name;
+
+}

--- a/src/main/java/com/example/epari/admin/dto/ApprovalRequestDTO.java
+++ b/src/main/java/com/example/epari/admin/dto/ApprovalRequestDTO.java
@@ -12,8 +12,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ApprovalRequestDTO {
 
+	private String username; // Cognito username
+
 	private Long courseId;
 
-	private String name;
+	private String name; // Username
 
 }

--- a/src/main/java/com/example/epari/admin/dto/CognitoUserDTO.java
+++ b/src/main/java/com/example/epari/admin/dto/CognitoUserDTO.java
@@ -1,0 +1,26 @@
+package com.example.epari.admin.dto;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Cognito 사용자 정보를 담는 DTO
+ */
+@Getter
+@Builder
+public class CognitoUserDTO {
+
+	private String username;
+
+	private String email;
+
+	private String status;
+
+	private LocalDateTime userCreateDate;
+
+	private Map<String, String> attributes;
+
+}

--- a/src/main/java/com/example/epari/admin/dto/CourseSearchResponseDTO.java
+++ b/src/main/java/com/example/epari/admin/dto/CourseSearchResponseDTO.java
@@ -1,0 +1,23 @@
+package com.example.epari.admin.dto;
+
+import lombok.Getter;
+
+/**
+ * 강의 검색 결과를 담는 응답 DTO
+ */
+@Getter
+public class CourseSearchResponseDTO {
+
+	private final Long id;
+
+	private final String name;
+
+	private final String instructor;
+
+	public CourseSearchResponseDTO(Long id, String name, String instructor) {
+		this.id = id;
+		this.name = name;
+		this.instructor = instructor;
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/exception/CognitoException.java
+++ b/src/main/java/com/example/epari/admin/exception/CognitoException.java
@@ -1,0 +1,15 @@
+package com.example.epari.admin.exception;
+
+import com.example.epari.global.exception.BusinessBaseException;
+import com.example.epari.global.exception.ErrorCode;
+
+/**
+ * Cognito 관련 예외
+ */
+public class CognitoException extends BusinessBaseException {
+
+	public CognitoException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/exception/CourseNotFoundException.java
+++ b/src/main/java/com/example/epari/admin/exception/CourseNotFoundException.java
@@ -1,0 +1,15 @@
+package com.example.epari.admin.exception;
+
+import com.example.epari.global.exception.BusinessBaseException;
+import com.example.epari.global.exception.ErrorCode;
+
+/**
+ * 강의를 찾을 수 없을 때 발생하는 예외
+ */
+public class CourseNotFoundException extends BusinessBaseException {
+
+	public CourseNotFoundException() {
+		super(ErrorCode.COURSE_NOT_FOUND);
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/service/AdminCourseService.java
+++ b/src/main/java/com/example/epari/admin/service/AdminCourseService.java
@@ -1,0 +1,30 @@
+package com.example.epari.admin.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.epari.admin.dto.CourseSearchResponseDTO;
+import com.example.epari.course.repository.CourseRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 관리자기 강의를 관리하는 비즈니스 로직을 처리하는 서비스 클래스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminCourseService {
+
+	private final CourseRepository courseRepository;
+
+	/**
+	 * 키워드 기반 강의 검색 메서드
+	 */
+	public List<CourseSearchResponseDTO> searchCourses(String keyword) {
+		return courseRepository.searchCoursesWithDTO(keyword);
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/service/AdminCourseService.java
+++ b/src/main/java/com/example/epari/admin/service/AdminCourseService.java
@@ -11,7 +11,7 @@ import com.example.epari.course.repository.CourseRepository;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 관리자기 강의를 관리하는 비즈니스 로직을 처리하는 서비스 클래스
+ * 관리자가 강의를 관리하는 비즈니스 로직을 처리하는 서비스 클래스
  */
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/epari/admin/service/AdminUserService.java
+++ b/src/main/java/com/example/epari/admin/service/AdminUserService.java
@@ -1,0 +1,50 @@
+package com.example.epari.admin.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.epari.admin.dto.ApprovalRequestDTO;
+import com.example.epari.admin.exception.CourseNotFoundException;
+import com.example.epari.course.domain.Course;
+import com.example.epari.course.domain.CourseStudent;
+import com.example.epari.course.repository.CourseRepository;
+import com.example.epari.course.repository.CourseStudentRepository;
+import com.example.epari.user.domain.Student;
+import com.example.epari.user.repository.StudentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 관리자기 사용자를 관리하는 비즈니스 로직을 처리하는 서비스 클래스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserService {
+
+	private final StudentRepository studentRepository;
+
+	private final CourseRepository courseRepository;
+
+	private final CourseStudentRepository courseStudentRepository;
+
+	/**
+	 * 사용자 승인 처리 메서드
+	 * 사용자 저장 및 과목 매핑 수행
+	 */
+	@Transactional
+	public void approveUser(String email, ApprovalRequestDTO request) {
+		// 1. 사용자 저장
+		Student student = Student
+				.createStudent(email, "PASSWORD", request.getName(), "010-1234-5678");
+
+		studentRepository.save(student);
+
+		// 2. 과목 매핑
+		Course course = courseRepository.findById(request.getCourseId())
+				.orElseThrow(CourseNotFoundException::new);
+
+		courseStudentRepository.save(new CourseStudent(course, student));
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/service/AdminUserService.java
+++ b/src/main/java/com/example/epari/admin/service/AdminUserService.java
@@ -15,7 +15,7 @@ import com.example.epari.user.repository.StudentRepository;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 관리자기 사용자를 관리하는 비즈니스 로직을 처리하는 서비스 클래스
+ * 관리자가 사용자를 관리하는 비즈니스 로직을 처리하는 서비스 클래스
  */
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/epari/admin/service/CognitoService.java
+++ b/src/main/java/com/example/epari/admin/service/CognitoService.java
@@ -67,11 +67,11 @@ public class CognitoService {
 	/**
 	 * 사용자 그룹을 변경
 	 */
-	public void changeUserGroup(String email, String groupName) {
+	public void changeUserGroup(String username, String groupName) {
 		// 1. 현재 그룹에서 제거
 		AdminRemoveUserFromGroupRequest removeRequest = AdminRemoveUserFromGroupRequest.builder()
 				.userPoolId(userPoolId)
-				.username(email)
+				.username(username)
 				.groupName("PENDING_ROLES")
 				.build();
 
@@ -80,7 +80,7 @@ public class CognitoService {
 		// 2. 새 그룹에 추가
 		AdminAddUserToGroupRequest addRequest = AdminAddUserToGroupRequest.builder()
 				.userPoolId(userPoolId)
-				.username(email)
+				.username(username)
 				.groupName(groupName)
 				.build();
 

--- a/src/main/java/com/example/epari/admin/service/CognitoService.java
+++ b/src/main/java/com/example/epari/admin/service/CognitoService.java
@@ -1,0 +1,88 @@
+package com.example.epari.admin.service;
+
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.epari.admin.dto.CognitoUserDTO;
+import com.example.epari.admin.exception.CognitoException;
+import com.example.epari.global.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.CognitoIdentityProviderException;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersInGroupRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersInGroupResponse;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
+
+/**
+ * Cognito 관련 비즈니스 로직을 처리하는 서비스 클래스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CognitoService {
+
+	private final CognitoIdentityProviderClient cognitoClient;
+
+	@Value("${aws.cognito.userpool.id}")
+	private String userPoolId;
+
+	/**
+	 * 그룹 이름을 입력받아 해당 그룹에 속한 사용자를 반환
+	 */
+	public List<CognitoUserDTO> getUsersByGroup(String groupName) {
+		try {
+			// 1. 그룹에 속한 사용자 목록 조회
+			ListUsersInGroupRequest listUsersRequest = ListUsersInGroupRequest.builder()
+					.userPoolId(userPoolId)
+					.groupName(groupName)
+					.build();
+
+			ListUsersInGroupResponse listUsersResponse =
+					cognitoClient.listUsersInGroup(listUsersRequest);
+
+			// 2. 사용자 정보를 DTO로 변환
+			return listUsersResponse.users().stream()
+					.map(this::convertToDTO)
+					.collect(Collectors.toList());
+		} catch (CognitoIdentityProviderException ex) {
+			log.error("Failed to fetch users from Cognito group: {}", groupName, ex);
+			throw new CognitoException(ErrorCode.COGNITO_USER_FETCH_ERROR);
+		}
+	}
+
+	private CognitoUserDTO convertToDTO(UserType user) {
+		Map<String, String> attributes = user.attributes().stream()
+				.collect(Collectors.toMap(
+						AttributeType::name,
+						AttributeType::value
+				));
+
+		return CognitoUserDTO.builder()
+				.username(user.username())
+				.email(getAttributeValue(user.attributes()))
+				.status(user.userStatus().toString())
+				.userCreateDate(user.userCreateDate().atZone(
+						ZoneId.systemDefault()).toLocalDateTime())
+				.attributes(attributes)
+				.build();
+	}
+
+	private String getAttributeValue(List<AttributeType> attributes) {
+		return attributes.stream()
+				.filter(attr -> attr.name().equals("email"))
+				.findFirst()
+				.map(AttributeType::value)
+				.orElse(null);
+	}
+
+}

--- a/src/main/java/com/example/epari/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/epari/course/repository/CourseRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.example.epari.admin.dto.CourseSearchResponseDTO;
 import com.example.epari.course.domain.Course;
 
 /**
@@ -59,5 +60,26 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 	boolean existsByCourseIdAndStudentEmail(
 			@Param("courseId") Long courseId,
 			@Param("studentEmail") String studentEmail);
+
+	/**
+	 * 키워드를 기반으로 강의 정보를 DTO로 직접 조회하는 쿼리 메서드
+	 * - 키워드가 없으면 전체 조회
+	 * - 필요한 컬럼만 선택적으로 조회
+	 * - new 연산자로 DTO 직접 매핑
+	 */
+	@Query("""
+			    SELECT new com.example.epari.admin.dto.CourseSearchResponseDTO(
+			        c.id,
+			        c.name,
+			        i.name
+			    )
+			    FROM Course c
+			    LEFT JOIN c.instructor i
+			    WHERE (:keyword IS NULL OR
+			           :keyword = '' OR
+			           LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')))
+			    ORDER BY c.name ASC
+			""")
+	List<CourseSearchResponseDTO> searchCoursesWithDTO(@Param("keyword") String keyword);
 
 }

--- a/src/main/java/com/example/epari/global/common/enums/UserRole.java
+++ b/src/main/java/com/example/epari/global/common/enums/UserRole.java
@@ -2,10 +2,14 @@ package com.example.epari.global.common.enums;
 
 import lombok.Getter;
 
+/**
+ * 사용자 역할을 정의하는 Enum 클래스
+ */
 @Getter
 public enum UserRole {
 	INSTRUCTOR("강사"),
-	STUDENT("수강생");
+	STUDENT("수강생"),
+	ADMIN("관리자");
 
 	private final String description;
 

--- a/src/main/java/com/example/epari/global/config/aws/AwsCognitoConfig.java
+++ b/src/main/java/com/example/epari/global/config/aws/AwsCognitoConfig.java
@@ -1,0 +1,23 @@
+package com.example.epari.global.config.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+
+@Configuration
+public class AwsCognitoConfig {
+
+	@Value("${aws.region}")
+	private String region;
+
+	@Bean
+	public CognitoIdentityProviderClient cognitoClient() {
+		return CognitoIdentityProviderClient.builder()
+				.region(Region.of(region))
+				.build();
+	}
+
+}

--- a/src/main/java/com/example/epari/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/epari/global/config/security/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
 						.requestMatchers("/actuator/health/**").permitAll() // Actuator 헬스체크 엔드포인트 허용
 						.requestMatchers("/api/instructor/**").hasRole("INSTRUCTOR")
 						.requestMatchers("/api/student/**").hasRole("STUDENT")
+						.requestMatchers("/api/admin/**").hasRole("ADMIN")
 						.anyRequest().authenticated()
 				)
 				.oauth2ResourceServer(oauth2 -> oauth2

--- a/src/main/java/com/example/epari/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorCode.java
@@ -31,7 +31,10 @@ public enum ErrorCode {
 
 	// Exam 관련 에러 코드 (EXAM)
 	EXAM_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM-001", "시험을 찾을 수 없습니다."),
-	EXAM_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM-002", "시험 결과를 찾을 수 없습니다.");
+	EXAM_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM-002", "시험 결과를 찾을 수 없습니다."),
+
+	// Cognito 관련 에러 코드 (CGT)
+	COGNITO_USER_FETCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CGT-001", "사용자 정보 조회에 실패했습니다.");
 
 	private final HttpStatus status;
 

--- a/src/main/java/com/example/epari/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorCode.java
@@ -34,7 +34,9 @@ public enum ErrorCode {
 	EXAM_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM-002", "시험 결과를 찾을 수 없습니다."),
 
 	// Cognito 관련 에러 코드 (CGT)
-	COGNITO_USER_FETCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CGT-001", "사용자 정보 조회에 실패했습니다.");
+	COGNITO_USER_FETCH_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CGT-001", "사용자 정보 조회에 실패했습니다."),
+	COGNITO_USER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "CGT-002", "사용자 정보를 찾을 수 없습니다."),
+	COGNITO_USER_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CGT-003", "사용자를 삭제하는 도중 오류가 발생했습니다.");
 
 	private final HttpStatus status;
 


### PR DESCRIPTION
## 관련 이슈
- Closes #78 

## 변경 사항
1. AWS Cognito 연동 구현
   - AwsCognitoConfig를 통한 Cognito 설정
   - CognitoService를 통한 사용자 관리 기능 구현
   - Cognito 관련 예외 처리 구현

2. 관리자 기능 구현
   - ADMIN Role 및 보안 설정 추가
   - 임시 회원 조회 기능 구현
   - 회원 승인/반려 프로세스 구현
   - 강의 검색 기능 구현

3. DTO 및 예외 처리
   - CognitoUserDTO, ApprovalRequestDTO 구현
   - CourseSearchResponseDTO 구현
   - CognitoException, CourseNotFoundException 추가

## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- Cognito 그룹을 통해 임시/정식 회원을 구분하고 관리합니다
- 회원 승인 시 자동으로 과목 매핑이 이루어집니다
- 강의 검색은 키워드 기반으로 구현되었습니다

## 추후 업무
- [ ] 강의 관리 기능 구현