### PR TITLE
[FEAT] 시험 문제 자동 채점기능 구현

### DIFF
--- a/src/main/java/com/example/epari/exam/controller/GradingController.java
+++ b/src/main/java/com/example/epari/exam/controller/GradingController.java
@@ -1,0 +1,88 @@
+package com.example.epari.exam.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.epari.exam.service.GradingService;
+import com.example.epari.exam.service.GradingService.ScoreStatistics;
+import com.example.epari.global.annotation.CurrentUserEmail;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 시험 채점 및 성적 통계 관련 요청을 처리하는 Controller
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/courses/{courseId}/exams/{examId}/grades")
+@RequiredArgsConstructor
+public class GradingController {
+
+	private final GradingService gradingService;
+
+	/**
+	 * 시험 결과 채점 요청
+	 * @param courseId 강의 ID
+	 * @param examId 시험 ID
+	 * @param resultId 채점할 시험 결과 ID
+	 * @param instructorEmail 강사 이메일
+	 * @return 채점 완료 응답
+	 */
+	@PostMapping("/results/{resultId}")
+	@PreAuthorize("hasRole('INSTRUCTOR') and @courseSecurityChecker.checkInstructorAccess(#courseId, #instructorEmail)")
+	public ResponseEntity<Void> gradeExam(
+			@PathVariable Long courseId,
+			@PathVariable Long examId,
+			@PathVariable Long resultId,
+			@CurrentUserEmail String instructorEmail) {
+
+		log.info("Grading request - courseId: {}, examId: {}, resultId: {}", courseId, examId, resultId);
+		gradingService.gradeExamResult(resultId);
+		return ResponseEntity.ok().build();
+	}
+
+	/**
+	 * 평균 점수 조회
+	 * @param courseId 강의 ID
+	 * @param examId 시험 ID
+	 * @param instructorEmail 강사 이메일
+	 * @return 평균 점수
+	 */
+	@GetMapping("/average")
+	@PreAuthorize("hasRole('INSTRUCTOR') and @courseSecurityChecker.checkInstructorAccess(#courseId, #instructorEmail)")
+	public ResponseEntity<Double> getAverageScore(
+			@PathVariable Long courseId,
+			@PathVariable Long examId,
+			@CurrentUserEmail String instructorEmail) {
+
+		log.info("Retrieving average score - courseId: {}, examId: {}", courseId, examId);
+		double averageScore = gradingService.calculateAverageScore(examId);
+		return ResponseEntity.ok(averageScore);
+	}
+
+	/**
+	 * 최고/최저 점수 통계 조회
+	 * @param courseId 강의 ID
+	 * @param examId 시험 ID
+	 * @param instructorEmail 강사 이메일
+	 * @return 점수 통계 정보
+	 */
+	@GetMapping("/statistics")
+	@PreAuthorize("hasRole('INSTRUCTOR') and @courseSecurityChecker.checkInstructorAccess(#courseId, #instructorEmail)")
+	public ResponseEntity<ScoreStatistics> getScoreStatistics(
+			@PathVariable Long courseId,
+			@PathVariable Long examId,
+			@CurrentUserEmail String instructorEmail) {
+
+		log.info("Retrieving score statistics - courseId: {}, examId: {}", courseId, examId);
+		ScoreStatistics statistics = gradingService.calculateScoreStatistics(examId);
+		return ResponseEntity.ok(statistics);
+	}
+}
+```

--- a/src/main/java/com/example/epari/exam/controller/GradingController.java
+++ b/src/main/java/com/example/epari/exam/controller/GradingController.java
@@ -2,26 +2,33 @@ package com.example.epari.exam.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.epari.exam.exception.GradingException;
+import com.example.epari.exam.exception.GradingNotPossibleException;
+import com.example.epari.exam.exception.InvalidScoreException;
 import com.example.epari.exam.service.GradingService;
 import com.example.epari.exam.service.GradingService.ScoreStatistics;
 import com.example.epari.global.annotation.CurrentUserEmail;
+import com.example.epari.global.exception.ErrorCode;
+import com.example.epari.global.exception.ErrorResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 
 /**
  * 시험 채점 및 성적 통계 관련 요청을 처리하는 Controller
  */
 @Slf4j
 @RestController
-@RequestMapping("/api/courses/{courseId}/exams/{examId}/grades")
 @RequiredArgsConstructor
+@RequestMapping("/api/courses/{courseId}/exams/{examId}/grades")
 public class GradingController {
 
 	private final GradingService gradingService;
@@ -84,5 +91,22 @@ public class GradingController {
 		ScoreStatistics statistics = gradingService.calculateScoreStatistics(examId);
 		return ResponseEntity.ok(statistics);
 	}
+
+	@ExceptionHandler(GradingException.class)
+    public ResponseEntity<ErrorResponse> handleGradingException(GradingException e) {
+        log.error("채점 처리 중 오류 발생", e);
+        return ErrorResponse.toResponseEntity(ErrorCode.GRADING_FAILED);
+    }
+
+    @ExceptionHandler(GradingNotPossibleException.class)
+    public ResponseEntity<ErrorResponse> handleGradingNotPossibleException(GradingNotPossibleException e) {
+        log.error("채점 불가능한 상태", e);
+        return ErrorResponse.toResponseEntity(ErrorCode.EXAM_NOT_SUBMITTED);
+    }
+
+    @ExceptionHandler(InvalidScoreException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidScoreException(InvalidScoreException e) {
+        log.error("유효하지 않은 점수", e);
+        return ErrorResponse.toResponseEntity(ErrorCode.INVALID_SCORE_VALUE);
+    }
 }
-```

--- a/src/main/java/com/example/epari/exam/domain/ExamQuestion.java
+++ b/src/main/java/com/example/epari/exam/domain/ExamQuestion.java
@@ -53,7 +53,7 @@ public abstract class ExamQuestion extends BaseTimeEntity {
 	@Column(nullable = false)
 	private ExamQuestionType type;
 
-	@Column(name = "correct_answer", nullable = false)  // 단일 정답 필드
+	@Column(name = "correct_answer", nullable = false)
 	private String correctAnswer;
 
 	@Embedded
@@ -73,9 +73,6 @@ public abstract class ExamQuestion extends BaseTimeEntity {
 		this.correctAnswer = correctAnswer;
 	}
 
-	// 정답 검증을 위한 추상 메소드
-	public abstract boolean validateAnswer(String studentAnswer);
-
 	public void setImage(QuestionImage image) {
 		this.image = image;
 	}
@@ -83,6 +80,24 @@ public abstract class ExamQuestion extends BaseTimeEntity {
 	void setExam(Exam exam) {
 		this.exam = exam;
 	}
+
+	/**
+	 * 학생의 답안을 채점하여 맞았는지 여부를 반환
+	 * @param studentAnswer 학생이 제출한 답안
+	 * @return 정답 여부
+	 */
+	public final boolean validateAnswer(String studentAnswer) {
+		if (studentAnswer == null || studentAnswer.trim().isEmpty()) {
+			return false;
+		}
+		return doValidateAnswer(studentAnswer.trim());
+	}
+
+	/**
+	 * 실제 답안 검증 로직을 구현하는 추상 메서드
+	 * 각 문제 타입별로 구체적인 검증 방식을 구현
+	 */
+	protected abstract boolean doValidateAnswer(String studentAnswer);
 
 	public void updateExamNumber(int newNumber) {
 		this.examNumber = newNumber;

--- a/src/main/java/com/example/epari/exam/domain/ExamScore.java
+++ b/src/main/java/com/example/epari/exam/domain/ExamScore.java
@@ -19,7 +19,6 @@ import lombok.NoArgsConstructor;
 /**
  * 개별 문제에 대한 학생의 답안과 채점 결과를 관리하는 엔티티
  */
-
 @Entity
 @Table(name = "exam_scores")
 @Getter
@@ -47,8 +46,6 @@ public class ExamScore extends BaseTimeEntity {
 	@Column(nullable = false)
 	private boolean temporary;
 
-	private String feedback;
-
 	@Builder
 	public ExamScore(ExamResult examResult, ExamQuestion question, String studentAnswer, boolean temporary) {
 		this.examResult = examResult;
@@ -62,21 +59,32 @@ public class ExamScore extends BaseTimeEntity {
 		this.examResult = examResult;
 	}
 
-	public void updateScore(int earnedScore, String feedback) {
-		this.earnedScore = earnedScore;
-		this.feedback = feedback;
-	}
-
+	/**
+	 * 답안 업데이트
+	 */
 	public void updateAnswer(String answer) {
 		this.studentAnswer = answer;
 	}
 
+	/**
+	 * 임시저장 상태 해제 (최종 제출)
+	 */
 	public void markAsSubmitted() {
 		this.temporary = false;
 	}
 
+	/**
+	 * 채점 결과 업데이트
+	 */
 	public void updateScore(int score) {
 		this.earnedScore = score;
+	}
+
+	/**
+	 * 정답 여부 확인
+	 */
+	public boolean isCorrect() {
+		return earnedScore > 0;
 	}
 
 }

--- a/src/main/java/com/example/epari/exam/domain/MultipleChoiceQuestion.java
+++ b/src/main/java/com/example/epari/exam/domain/MultipleChoiceQuestion.java
@@ -36,8 +36,22 @@ public class MultipleChoiceQuestion extends ExamQuestion {
 	}
 
 	@Override
-	public boolean validateAnswer(String studentAnswer) {
-		return getCorrectAnswer().equals(studentAnswer);
+	protected boolean doValidateAnswer(String studentAnswer) {
+		try {
+			// 선택지 번호가 숫자인지 확인
+			int selectedNumber = Integer.parseInt(studentAnswer);
+
+			// 유효한 선택지 범위인지 확인
+			if (selectedNumber < 1 || selectedNumber > choices.size()) {
+				return false;
+			}
+
+			// 정답과 일치하는지 확인
+			return studentAnswer.equals(getCorrectAnswer());
+
+		} catch (NumberFormatException e) {
+			return false;
+		}
 	}
 
 	public void addChoice(Choice choice) {

--- a/src/main/java/com/example/epari/exam/domain/SubjectiveQuestion.java
+++ b/src/main/java/com/example/epari/exam/domain/SubjectiveQuestion.java
@@ -22,9 +22,12 @@ public class SubjectiveQuestion extends ExamQuestion {
 	}
 
 	@Override
-	public boolean validateAnswer(String studentAnswer) {
-		// 주관식은 좀 더 유연한 검증이 필요할 수 있음
-		return getCorrectAnswer().trim().equalsIgnoreCase(studentAnswer.trim());
+	protected boolean doValidateAnswer(String studentAnswer) {
+		// 대소문자 무시, 앞뒤 공백 제거 후 비교
+		String normalizedCorrectAnswer = getCorrectAnswer().trim().toLowerCase();
+		String normalizedStudentAnswer = studentAnswer.trim().toLowerCase();
+
+		return normalizedCorrectAnswer.equals(normalizedStudentAnswer);
 	}
 
 }

--- a/src/main/java/com/example/epari/exam/exception/GradingException.java
+++ b/src/main/java/com/example/epari/exam/exception/GradingException.java
@@ -1,0 +1,15 @@
+package com.example.epari.exam.exception;
+
+public class GradingException extends RuntimeException {
+    
+    private static final long serialVersionUID = 1L;
+    
+    public GradingException(String message) {
+        super(message);
+    }
+    
+    public GradingException(String message, Throwable cause) {
+        super(message, cause); 
+    }
+}
+

--- a/src/main/java/com/example/epari/exam/exception/GradingNotPossibleException.java
+++ b/src/main/java/com/example/epari/exam/exception/GradingNotPossibleException.java
@@ -1,0 +1,8 @@
+package com.example.epari.exam.exception;
+
+public class GradingNotPossibleException extends GradingException {
+    
+    public GradingNotPossibleException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/epari/exam/exception/InvalidScoreException.java
+++ b/src/main/java/com/example/epari/exam/exception/InvalidScoreException.java
@@ -1,0 +1,8 @@
+package com.example.epari.exam.exception;
+
+public class InvalidScoreException extends GradingException {
+    
+    public InvalidScoreException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/epari/exam/repository/ExamQuestionRepository.java
+++ b/src/main/java/com/example/epari/exam/repository/ExamQuestionRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.epari.exam.domain.ExamQuestion;
 
@@ -18,6 +20,10 @@ public interface ExamQuestionRepository extends JpaRepository<ExamQuestion, Long
 	// 시험에 속한 문제인지 확인
 	boolean existsByIdAndExamId(Long questionId, Long examId);
 
-	Optional<ExamQuestion> findByExamIdAndId(Long examId, Long id);
+	@Query("SELECT q FROM ExamQuestion q WHERE q.exam.id = :examId AND q.id = :questionId")
+    Optional<ExamQuestion> findByExamIdAndId(
+            @Param("examId") Long examId, 
+            @Param("questionId") Long questionId
+    );
 
 }

--- a/src/main/java/com/example/epari/exam/repository/ExamResultRepository.java
+++ b/src/main/java/com/example/epari/exam/repository/ExamResultRepository.java
@@ -38,7 +38,7 @@ public interface ExamResultRepository extends JpaRepository<ExamResult, Long> {
 			@Param("studentEmail") String studentEmail
 	);
 
-	// 시험 상태별 결과 조회
+	// 특정 상태의 시험 결과 조회
 	@Query("SELECT er FROM ExamResult er " +
 			"WHERE er.exam.id = :examId " +
 			"AND er.status = :status")
@@ -47,11 +47,20 @@ public interface ExamResultRepository extends JpaRepository<ExamResult, Long> {
 			@Param("status") ExamStatus status
 	);
 
+	// 채점 대기중인 시험 결과 조회 (자동 채점용)
 	@Query("""
-			    SELECT er FROM ExamResult er
-			    JOIN FETCH er.exam e
-			    WHERE er.status = 'IN_PROGRESS'
-			    AND e.examDateTime <= :baseTime
+			SELECT er FROM ExamResult er
+			WHERE er.status = 'SUBMITTED'
+			AND er.submitTime <= :baseTime
+			""")
+	List<ExamResult> findPendingGradingExams(@Param("baseTime") LocalDateTime baseTime);
+
+	// 시간 초과된 진행중 시험 조회 (자동 제출용)
+	@Query("""
+			SELECT er FROM ExamResult er
+			JOIN FETCH er.exam e
+			WHERE er.status = 'IN_PROGRESS'
+			AND e.examDateTime <= :baseTime
 			""")
 	List<ExamResult> findExpiredExams(@Param("baseTime") LocalDateTime baseTime);
 

--- a/src/main/java/com/example/epari/exam/scheduler/AutoGradingScheduler.java
+++ b/src/main/java/com/example/epari/exam/scheduler/AutoGradingScheduler.java
@@ -69,4 +69,3 @@ public class AutoGradingScheduler {
 		}
 	}
 }
-```

--- a/src/main/java/com/example/epari/exam/scheduler/AutoGradingScheduler.java
+++ b/src/main/java/com/example/epari/exam/scheduler/AutoGradingScheduler.java
@@ -1,0 +1,72 @@
+package com.example.epari.exam.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.epari.exam.domain.ExamResult;
+import com.example.epari.exam.repository.ExamResultRepository;
+import com.example.epari.exam.service.GradingService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 시험 자동 제출 및 채점을 처리하는 스케줄러
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AutoGradingScheduler {
+
+	private final ExamResultRepository examResultRepository;
+	private final GradingService gradingService;
+
+	/**
+	 * 1분마다 실행되는 시험 자동 제출 처리
+	 * 시험 시간이 종료된 시험을 자동으로 제출 처리
+	 */
+	@Scheduled(fixedRate = 60000)
+	@Transactional
+	public void autoSubmitExpiredExams() {
+		LocalDateTime baseTime = LocalDateTime.now().minusMinutes(1);
+		List<ExamResult> expiredExams = examResultRepository.findExpiredExams(baseTime);
+
+		for (ExamResult result : expiredExams) {
+			try {
+				result.submit(true); // force submit
+				log.info("Auto submitted exam - resultId: {}, studentId: {}, submittedAt: {}",
+						result.getId(),
+						result.getStudent().getId(),
+						result.getSubmitTime());
+			} catch (Exception e) {
+				log.error("Failed to auto submit exam - resultId: " + result.getId(), e);
+			}
+		}
+	}
+
+	/**
+	 * 5분마다 실행되는 자동 채점 처리
+	 * 제출된 시험 중 채점되지 않은 시험을 자동으로 채점
+	 */
+	@Scheduled(fixedRate = 300000)
+	public void autoGradeSubmittedExams() {
+		LocalDateTime baseTime = LocalDateTime.now().minusMinutes(5);
+		List<ExamResult> pendingExams = examResultRepository.findPendingGradingExams(baseTime);
+
+		for (ExamResult result : pendingExams) {
+			try {
+				gradingService.gradeExamResult(result.getId());
+				log.info("Auto graded exam - resultId: {}, totalScore: {}",
+						result.getId(),
+						result.getTotalScore());
+			} catch (Exception e) {
+				log.error("Failed to auto grade exam - resultId: " + result.getId(), e);
+			}
+		}
+	}
+}
+```

--- a/src/main/java/com/example/epari/exam/service/GradingService.java
+++ b/src/main/java/com/example/epari/exam/service/GradingService.java
@@ -25,7 +25,10 @@ public class GradingService {
 
 	private final ExamResultRepository examResultRepository;
 
-	public void gradeExamResult(ExamResult examResult) {
+	/**
+     * 단순 채점 처리 (내부용)
+     */
+	public void processGrading(ExamResult examResult) {
 		if (examResult.getStatus() != ExamStatus.SUBMITTED) {
 			throw new IllegalStateException("제출된 시험만 채점할 수 있습니다.");
 		}
@@ -58,7 +61,7 @@ public class GradingService {
 	}
 
 	/**
-	 * 개별 시험 결과 채점
+	 * 개별 시험 결과 채점 (API용)
 	 */
 	public void gradeExamResult(Long examResultId) {
 		ExamResult examResult = examResultRepository.findById(examResultId)

--- a/src/main/java/com/example/epari/exam/service/GradingService.java
+++ b/src/main/java/com/example/epari/exam/service/GradingService.java
@@ -33,21 +33,18 @@ public class GradingService {
 			throw new IllegalStateException("제출된 시험만 채점할 수 있습니다.");
 		}
 
-		int totalScore = 0;
-
 		for (ExamScore score : examResult.getScores()) {
 			ExamQuestion question = score.getQuestion();
 			String studentAnswer = score.getStudentAnswer();
-
+			
 			// 답안 채점
 			boolean isCorrect = question.validateAnswer(studentAnswer);
 			int earnedScore = isCorrect ? question.getScore() : 0;
 			score.updateScore(earnedScore);
-
-			totalScore += earnedScore;
 		}
-
-		examResult.updateStatus(ExamStatus.GRADED);
+	
+		// 총점 계산 및 상태 업데이트
+		examResult.updateScore();  // updateStatus 대신 updateScore 호출
 		examResultRepository.save(examResult);
 	}
 

--- a/src/main/java/com/example/epari/exam/service/GradingService.java
+++ b/src/main/java/com/example/epari/exam/service/GradingService.java
@@ -1,0 +1,53 @@
+package com.example.epari.exam.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.epari.exam.domain.ExamQuestion;
+import com.example.epari.exam.domain.ExamResult;
+import com.example.epari.exam.domain.ExamScore;
+import com.example.epari.exam.repository.ExamResultRepository;
+import com.example.epari.global.common.enums.ExamStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GradingService {
+
+	private final ExamResultRepository examResultRepository;
+
+	public void gradeExamResult(ExamResult examResult) {
+		if (examResult.getStatus() != ExamStatus.SUBMITTED) {
+			throw new IllegalStateException("제출된 시험만 채점할 수 있습니다.");
+		}
+
+		int totalScore = 0;
+
+		for (ExamScore score : examResult.getScores()) {
+			ExamQuestion question = score.getQuestion();
+			String studentAnswer = score.getStudentAnswer();
+
+			// 답안 채점
+			boolean isCorrect = question.validateAnswer(studentAnswer);
+			int earnedScore = isCorrect ? question.getScore() : 0;
+			score.updateScore(earnedScore);
+
+			totalScore += earnedScore;
+		}
+
+		examResult.updateStatus(ExamStatus.GRADED);
+		examResultRepository.save(examResult);
+	}
+
+	@Transactional(readOnly = true)
+	public boolean verifyTotalScore(ExamResult examResult) {
+		int calculatedTotal = examResult.getScores().stream()
+				.mapToInt(ExamScore::getEarnedScore)
+				.sum();
+
+		return calculatedTotal == examResult.getEarnedScore();
+	}
+
+}

--- a/src/main/java/com/example/epari/exam/service/GradingService.java
+++ b/src/main/java/com/example/epari/exam/service/GradingService.java
@@ -15,10 +15,12 @@ import com.example.epari.global.exception.ErrorCode;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class GradingService {
 
 	private final ExamResultRepository examResultRepository;

--- a/src/main/java/com/example/epari/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorCode.java
@@ -29,7 +29,7 @@ public enum ErrorCode {
 	VERIFICATION_CODE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "AUTH-009", "잠시 후 다시 시도해주세요."),
 
 	// Student 관련 에러 코드(ST
-    STUDENT_NOT_FOUND(HttpStatus.NOT_FOUND, "STD-001", "학생 정보를 찾을 수 없습니다."),
+	STUDENT_NOT_FOUND(HttpStatus.NOT_FOUND, "STD-001", "학생 정보를 찾을 수 없습니다."),
 
 	// Course 관련 에러 코드 (CRS)
 	COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "CRS-001", "강의를 찾을 수 없습니다."),
@@ -39,9 +39,9 @@ public enum ErrorCode {
 	ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ASM-001", "과제를 찾을 수 없습니다."),
 	SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "ASM-002", "과제 제출물을 찾을 수 없습니다."),
 
-    // Question 관련 에러 코드(EXAM)
-    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QST-001", "문제를 찾을 수 없습니다."),
-    QUESTION_HAS_SUBMISSIONS(HttpStatus.BAD_REQUEST, "QST-002", "답안이 제출된 문제는 삭제할 수 없습니다."),
+	// Question 관련 에러 코드(EXAM)
+	QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QST-001", "문제를 찾을 수 없습니다."),
+	QUESTION_HAS_SUBMISSIONS(HttpStatus.BAD_REQUEST, "QST-002", "답안이 제출된 문제는 삭제할 수 없습니다."),
 
 	// Exam 관련 에러 코드 (EXAM)
 	EXAM_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM-001", "시험을 찾을 수 없습니다."),
@@ -73,7 +73,14 @@ public enum ErrorCode {
 
 	// 알림 관련 에러 코드 (NTF)
 	NOTIFICATION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NTF-001", "알림 발송에 실패했습니다."),
-	SES_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NTF-002", "이메일 서비스 연동 중 오류가 발생했습니다.");
+	SES_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NTF-002", "이메일 서비스 연동 중 오류가 발생했습니다."),
+
+	// 채점 관련 에러 코드 (GRD)
+	EXAM_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "GRD-001", "제출되지 않은 시험은 채점할 수 없습니다."),
+	EXAM_ALREADY_GRADED(HttpStatus.BAD_REQUEST, "GRD-002", "이미 채점이 완료된 시험입니다."),
+	GRADING_IN_PROGRESS(HttpStatus.BAD_REQUEST, "GRD-003", "채점이 진행 중인 시험입니다."),
+	INVALID_SCORE_VALUE(HttpStatus.BAD_REQUEST, "GRD-004", "유효하지 않은 점수입니다."),
+	GRADING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "GRD-005", "채점 처리 중 오류가 발생했습니다.");
 
 	private final HttpStatus status;
 

--- a/src/main/java/com/example/epari/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorCode.java
@@ -77,10 +77,10 @@ public enum ErrorCode {
 
 	// 채점 관련 에러 코드 (GRD)
 	EXAM_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "GRD-001", "제출되지 않은 시험은 채점할 수 없습니다."),
-	EXAM_ALREADY_GRADED(HttpStatus.BAD_REQUEST, "GRD-002", "이미 채점이 완료된 시험입니다."),
-	GRADING_IN_PROGRESS(HttpStatus.BAD_REQUEST, "GRD-003", "채점이 진행 중인 시험입니다."),
-	INVALID_SCORE_VALUE(HttpStatus.BAD_REQUEST, "GRD-004", "유효하지 않은 점수입니다."),
-	GRADING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "GRD-005", "채점 처리 중 오류가 발생했습니다.");
+    EXAM_ALREADY_GRADED(HttpStatus.BAD_REQUEST, "GRD-002", "이미 채점이 완료된 시험입니다."),
+    GRADING_IN_PROGRESS(HttpStatus.BAD_REQUEST, "GRD-003", "채점이 진행 중인 시험입니다."),
+    INVALID_SCORE_VALUE(HttpStatus.BAD_REQUEST, "GRD-004", "유효하지 않은 점수입니다."),
+    GRADING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "GRD-005", "채점 처리 중 오류가 발생했습니다.");
 
 	private final HttpStatus status;
 

--- a/src/main/java/com/example/epari/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorResponse.java
@@ -3,6 +3,8 @@ package com.example.epari.global.exception;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
+
 import lombok.Getter;
 
 /**
@@ -38,4 +40,16 @@ public class ErrorResponse {
 		return new ErrorResponse(errorCode, errors);
 	}
 
+	    public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode errorCode) {
+        return ResponseEntity
+            .status(errorCode.getStatus())
+            .body(ErrorResponse.of(errorCode));
+    }
+
+    public static ResponseEntity<ErrorResponse> toResponseEntity(ErrorCode errorCode, List<ValidationError> errors) {
+        return ResponseEntity
+            .status(errorCode.getStatus())
+            .body(ErrorResponse.of(errorCode, errors));
+
+}
 }

--- a/src/main/java/com/example/epari/global/init/InitDataLoader.java
+++ b/src/main/java/com/example/epari/global/init/InitDataLoader.java
@@ -1419,9 +1419,9 @@ public class InitDataLoader implements ApplicationRunner {
 								.build();
 
 						if (question.validateAnswer(studentAnswer)) {
-							score.updateScore(question.getScore(), "정답입니다.");
+							score.updateScore(question.getScore());
 						} else {
-							score.updateScore(0, "오답입니다. 정답은 " + question.getCorrectAnswer() + "입니다.");
+							score.updateScore(0);
 						}
 
 						result.addScore(score);


### PR DESCRIPTION
## 관련 이슈  
- Closes #93  

## 변경 사항  
**1. 시험 채점 서비스 구현**
  - GradingService에 자동 채점 처리 메서드 `processGrading` 구현
     - 객관식/주관식 문제를 문자열 일치 여부로 채점  
     - 각 문제별 점수 계산 및 총점 업데이트  
   - GradingService에 `verifyTotalScore`에서 채점 결과 검증 메서드 구현
     - 개별 문제 점수 합계와 총점 일치 여부 확인  
   - GradingService에 `gradeExamResult`에 API용 채점 메서드 구현
     - 채점 권한 검증 및 예외 처리  
     - 채점 결과 로깅  

**3. 채점 통계 기능 구현**  
   - GradingService에 `calculateAverageScore`에 평균 점수 계산 메서드 구현
     - 시험별 평균 점수 산출  
   - GradingService에 `calculateScoreStatistics`에 점수 통계 메서드 구현
     - 최고/최저 점수 계산  
     - 정답률 통계 산출  

**4. 채점 관련 API 구현**  
   - GradingController에 채점 요청 및 통계 조회 엔드포인트 구현  
   - 채점 관련 예외 처리기 구현
     - `GradingException`  
     - `GradingNotPossibleException`  
     - `InvalidScoreException`  

**5. AutoGradingScheduler 클래스로 자동 채점 스케줄러 구현**  
   - 미채점 시험 자동 채점 기능  
   - 시험 시간 초과 시 자동 제출 처리  
   - 채점 실패 시 예외 처리 및 로깅  

## 스크린샷
|기능|스크린샷|
|--|--|
|자동 채점 기능|<img width="917" alt="스크린샷 2024-11-20 오후 4 58 35" src="https://github.com/user-attachments/assets/02465749-7773-492a-9803-d8b8201407c0">|
|평균 점수 조회|![스크린샷 2024-11-20 오후 4 56 31](https://github.com/user-attachments/assets/cafdbc1e-f287-47fe-900c-618510393f06)|
|최고/최저 점수 조회|![image](https://github.com/user-attachments/assets/62699622-3bc4-4a48-b429-70c337238b6a)|


## 체크리스트  
- [x] 코드 컨벤션을 준수하였습니까?  
- [x] 모든 테스트를 통과하였습니까?  
- [x] 관련 문서를 업데이트하였습니까?  

## 공유 사항  
채점 프로세스 흐름 참고 부탁드립니다.

- **채점 프로세스 흐름** 
  - 시험 제출(`SUBMITTED`) → 자동 채점 → 채점 완료(`GRADED`)  
  - 객관식/주관식 문제 모두 정확한 문자열 일치 시 정답 처리  
  - 총점 자동 계산 및 통계 처리  


## 추후 업무  
- [ ] 코드 효율성을 높이기 위한 리팩토링