### PR TITLE
[FEAT] Redis 캐시 시스템 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // Spring Data Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     // Spring Security & OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // Cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     // Spring Security & OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'

--- a/src/main/java/com/example/epari/course/service/CurriculumService.java
+++ b/src/main/java/com/example/epari/course/service/CurriculumService.java
@@ -2,6 +2,7 @@ package com.example.epari.course.service;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,11 @@ public class CurriculumService {
 	/**
 	 * 특정 강의 커리큘럼 조회
 	 */
+	@Cacheable(
+			value = "curriculums",
+			key = "#courseId",
+			unless = "#result.isEmpty()"
+	)
 	public List<CurriculumResponseDto> getCurriculumsByCourseId(Long courseId) {
 		return curriculumRepository.findAllByCourseId(courseId);
 	}

--- a/src/main/java/com/example/epari/global/config/RedisConfig.java
+++ b/src/main/java/com/example/epari/global/config/RedisConfig.java
@@ -1,0 +1,89 @@
+package com.example.epari.global.config;
+
+import java.time.Duration;
+
+import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Redis 설정 클래스
+ * Redis 캐시 및 템플릿 설정을 관리
+ */
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+	/**
+	 * Redis 템플릿 빈 설정
+	 * Redis 데이터 접근을 위한 템플릿을 구성
+	 */
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		// 문자열 및 JSON 직렬화 도구 생성
+		StringRedisSerializer stringSerializer = new StringRedisSerializer();
+		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer();
+
+		// Redis key는 문자열로 직렬화 (가독성과 디버깅을 위해)
+		template.setKeySerializer(stringSerializer);
+		template.setHashKeySerializer(stringSerializer);
+
+		// 값은 JSON 형식으로 직렬화 (객체 저장을 위해)
+		template.setValueSerializer(jsonSerializer);
+		template.setHashValueSerializer(jsonSerializer);
+
+		// 기본 직렬화 도구 설정 (명시되지 않은 타입을 위해)
+		template.setDefaultSerializer(jsonSerializer);
+
+		// 트랜잭션 지원 활성화
+		template.setEnableTransactionSupport(true);
+		template.afterPropertiesSet();
+
+		return template;
+	}
+
+	/**
+	 * Redis 캐시 매니저 빈 설정
+	 * 캐시 동작 방식과 설정을 정의
+	 */
+	@Bean
+	public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+				.serializeKeysWith(
+						RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+				)
+				.serializeValuesWith(
+						RedisSerializationContext.SerializationPair.fromSerializer(
+								new GenericJackson2JsonRedisSerializer())
+				)
+				.entryTtl(Duration.ofMinutes(30))  // 캐시 데이터 유효 시간: 30분
+				.disableCachingNullValues()        // null 값 캐시 방지
+				.prefixCacheNameWith("epari::");   // 키 충돌 방지를 위한 접두사
+
+		return RedisCacheManager.builder(connectionFactory)
+				.cacheDefaults(config)
+				.transactionAware()  // 트랜잭션 인지 활성화
+				.build();
+	}
+
+	/**
+	 * 캐시별 개별 설정을 위한 커스터마이저
+	 * 각 캐시마다 다른 TTL 등을 설정할 수 있습니다.
+	 */
+	@Bean
+	public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
+		return (builder) -> builder.build();
+	}
+
+}

--- a/src/main/java/com/example/epari/global/config/RedisConfig.java
+++ b/src/main/java/com/example/epari/global/config/RedisConfig.java
@@ -1,8 +1,9 @@
 package com.example.epari.global.config;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.springframework.boot.autoconfigure.cache.RedisCacheManagerBuilderCustomizer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,10 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
 /**
  * Redis 설정 클래스
  * Redis 캐시 및 템플릿 설정을 관리
@@ -23,23 +28,43 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
 	/**
+	 * Java 8 이상 날짜/시간 타입을 위한 Jackson ObjectMapper 설정
+	 */
+	@Bean
+	public ObjectMapper objectMapper() {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());  // JSR-310 모듈 등록
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);  // ISO-8601 형식으로 직렬화
+		return mapper;
+	}
+
+	/**
+	 * 커스텀 ObjectMapper를 사용하는 JSON 직렬화 도구
+	 */
+	@Bean
+	public GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer(ObjectMapper objectMapper) {
+		return new GenericJackson2JsonRedisSerializer(objectMapper);
+	}
+
+	/**
 	 * Redis 템플릿 빈 설정
 	 * Redis 데이터 접근을 위한 템플릿을 구성
 	 */
 	@Bean
-	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+	public RedisTemplate<String, Object> redisTemplate(
+			RedisConnectionFactory connectionFactory,
+			GenericJackson2JsonRedisSerializer jsonSerializer) {
 		RedisTemplate<String, Object> template = new RedisTemplate<>();
 		template.setConnectionFactory(connectionFactory);
 
-		// 문자열 및 JSON 직렬화 도구 생성
+		// 문자열 직렬화 도구
 		StringRedisSerializer stringSerializer = new StringRedisSerializer();
-		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer();
 
 		// Redis key는 문자열로 직렬화 (가독성과 디버깅을 위해)
 		template.setKeySerializer(stringSerializer);
 		template.setHashKeySerializer(stringSerializer);
 
-		// 값은 JSON 형식으로 직렬화 (객체 저장을 위해)
+		// 값은 커스텀 JSON 직렬화 도구 사용 (객체 저장을 위해)
 		template.setValueSerializer(jsonSerializer);
 		template.setHashValueSerializer(jsonSerializer);
 
@@ -54,36 +79,57 @@ public class RedisConfig {
 	}
 
 	/**
-	 * Redis 캐시 매니저 빈 설정
-	 * 캐시 동작 방식과 설정을 정의
+	 * 기본 Redis 캐시 설정을 정의하는 빈
 	 */
 	@Bean
-	public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+	public RedisCacheConfiguration defaultCacheConfig(GenericJackson2JsonRedisSerializer jsonSerializer) {
+		return RedisCacheConfiguration.defaultCacheConfig()
 				.serializeKeysWith(
 						RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
 				)
 				.serializeValuesWith(
-						RedisSerializationContext.SerializationPair.fromSerializer(
-								new GenericJackson2JsonRedisSerializer())
+						RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer)
 				)
-				.entryTtl(Duration.ofMinutes(30))  // 캐시 데이터 유효 시간: 30분
+				.entryTtl(Duration.ofMinutes(30))  // 기본 캐시 유효 시간: 30분
 				.disableCachingNullValues()        // null 값 캐시 방지
 				.prefixCacheNameWith("epari::");   // 키 충돌 방지를 위한 접두사
+	}
+
+	/**
+	 * 캐시별 설정을 생성하는 메서드
+	 */
+	private Map<String, RedisCacheConfiguration> createCacheConfigurations(
+			RedisCacheConfiguration defaultCacheConfig) {
+		Map<String, RedisCacheConfiguration> configMap = new HashMap<>();
+
+		// 캐시별 설정 추가
+		configMap.put("curriculums", defaultCacheConfig.entryTtl(CachingTTL.CURRICULUM));
+
+		return configMap;
+	}
+
+	/**
+	 * Redis 캐시 매니저 빈 설정
+	 */
+	@Bean
+	public RedisCacheManager cacheManager(
+			RedisConnectionFactory connectionFactory,
+			RedisCacheConfiguration defaultCacheConfig) {
 
 		return RedisCacheManager.builder(connectionFactory)
-				.cacheDefaults(config)
-				.transactionAware()  // 트랜잭션 인지 활성화
+				.cacheDefaults(defaultCacheConfig)
+				.withInitialCacheConfigurations(createCacheConfigurations(defaultCacheConfig))
+				.transactionAware()
 				.build();
 	}
 
 	/**
-	 * 캐시별 개별 설정을 위한 커스터마이저
-	 * 각 캐시마다 다른 TTL 등을 설정할 수 있습니다.
+	 * 캐시별 TTL 설정을 관리하는 상수
 	 */
-	@Bean
-	public RedisCacheManagerBuilderCustomizer redisCacheManagerBuilderCustomizer() {
-		return (builder) -> builder.build();
+	private static class CachingTTL {
+
+		public static final Duration CURRICULUM = Duration.ofHours(12);
+
 	}
 
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -32,6 +32,20 @@ spring:
       max-file-size: 10MB
       max-request-size: 10MB
 
+  data:
+    redis:
+      host: ${REDIS_HOST}  # ElastiCache 엔드포인트
+      port: ${REDIS_PORT:6379}
+      timeout: 3000       # 연결 타임아웃 (ms)
+      ssl:
+        enabled: true
+      lettuce:
+        pool:
+          max-active: 8   # 풀의 최대 연결 수
+          max-idle: 8     # 풀의 최대 유휴 연결 수
+          min-idle: 2     # 풀의 최소 유휴 연결 수
+          max-wait: -1ms  # 풀이 바쁠 때 연결을 기다리는 최대 시간
+
 ### AWS S3 Configuration ###
 aws:
   s3:


### PR DESCRIPTION
## 관련 이슈
- Closes #97 

## 변경 사항
1. Redis 캐시 시스템 구축
   - Redis 및 Cache 의존성 추가
   - LocalDate 직렬화를 위한 Jackson JSR-310 의존성 추가
   - Redis 연결 설정 구현 (SSL, Connection Pool, Timeout)

2. 캐시 관리 시스템 구현
   - ObjectMapper를 통한 날짜/시간 직렬화 설정
   - 캐시별 TTL 관리 클래스 (CachingTTL) 구현
   - 커리큘럼 전용 캐시 설정 (12시간)

3. 커리큘럼 조회 캐시 적용
   - 강의별 커리큘럼 조회에 @Cacheable 적용
   - courseId 기반 캐시 키 설정
   - 빈 결과 제외 캐시 조건 설정

## 스크린샷

|상태|스크린샷|
|---|---|
|캐시 적용 전|![캐시 적용 전](https://github.com/user-attachments/assets/16863edf-089f-4871-b572-cddf0efa2a17)|
|캐시 적용 후|![캐시 적용 후](https://github.com/user-attachments/assets/15480446-1153-4f0b-9107-a09c08403222)|


## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- Redis 연결은 SSL을 통해 보안 강화
- 개발/운영 환경에 따른 SSL 설정 분기 처리
- Connection Pool 및 타임아웃 설정으로 안정성 확보
- 커리큘럼 데이터는 12시간 캐시 유지

## 추후 업무
- [ ] 캐시 무효화 전략 수립