### PR TITLE
[FEAT] 시험 모든 학생 성적 조회 및 학생의 본인 성적 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/epari/exam/controller/ExamSubmissionController.java
+++ b/src/main/java/com/example/epari/exam/controller/ExamSubmissionController.java
@@ -1,9 +1,9 @@
 package com.example.epari.exam.controller;
 
-import org.apache.tomcat.util.net.openssl.ciphers.Authentication;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,11 +13,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.epari.exam.dto.common.AnswerSubmissionDto;
+import com.example.epari.exam.dto.common.ExamResultDetailDto;
+import com.example.epari.exam.dto.common.ExamResultSummaryDto;
 import com.example.epari.exam.dto.common.ExamSubmissionStatusDto;
 import com.example.epari.exam.service.ExamSubmissionService;
 import com.example.epari.global.annotation.CurrentUserEmail;
-import com.example.epari.global.exception.BusinessBaseException;
-import com.example.epari.global.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -87,6 +87,30 @@ public class ExamSubmissionController {
 
 		ExamSubmissionStatusDto status = examSubmissionService.getSubmissionStatus(courseId, examId, email);
 		return ResponseEntity.ok(status);
+	}
+
+	// 학생 결과
+	@GetMapping("/result")
+	@PreAuthorize("hasRole('STUDENT') and @courseSecurityChecker.checkStudentAccess(#courseId, #studentEmail)")
+	public ResponseEntity<ExamResultDetailDto> getStudentExamResult(
+			@PathVariable Long courseId,
+			@PathVariable Long examId,
+			@CurrentUserEmail String studentEmail) {
+
+		ExamResultDetailDto result = examSubmissionService.getStudentExamResult(courseId, examId, studentEmail);
+		return ResponseEntity.ok(result);
+	}
+
+	//
+	@GetMapping("/results")
+	@PreAuthorize("hasRole('INSTRUCTOR') and @courseSecurityChecker.checkInstructorAccess(#courseId, #email)")
+	public ResponseEntity<List<ExamResultSummaryDto>> getExamResults(
+			@PathVariable Long courseId,
+			@PathVariable Long examId,
+			@CurrentUserEmail String email) {
+
+		List<ExamResultSummaryDto> results = examSubmissionService.getExamResults(courseId, examId);
+		return ResponseEntity.ok(results);
 	}
 
 }

--- a/src/main/java/com/example/epari/exam/domain/Exam.java
+++ b/src/main/java/com/example/epari/exam/domain/Exam.java
@@ -32,44 +32,44 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Exam extends BaseTimeEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column(nullable = false)
-    private String title;
+	@Column(nullable = false)
+	private String title;
 
-    @Column(nullable = false)
-    private LocalDateTime examDateTime;
+	@Column(nullable = false)
+	private LocalDateTime examDateTime;
 
-    @Column(nullable = false)
-    private Integer duration;
+	@Column(nullable = false)
+	private Integer duration;
 
-    @Column(nullable = false)
-    private Integer totalScore;
+	@Column(nullable = false)
+	private Integer totalScore;
 
-    @Column(length = 1000)
-    private String description;
+	@Column(length = 1000)
+	private String description;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id")
-    private Course course;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "course_id")
+	private Course course;
 
-    @OneToMany(mappedBy = "exam", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ExamQuestion> questions = new ArrayList<>();
+	@OneToMany(mappedBy = "exam", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<ExamQuestion> questions = new ArrayList<>();
 
-    @Builder
-    private Exam(String title, LocalDateTime examDateTime,
-            Integer duration, Integer totalScore, String description, Course course) {
-        this.title = title;
-        this.examDateTime = examDateTime;
-        this.duration = duration;
-        this.totalScore = totalScore;
-        this.description = description;
-        this.course = course;
-    }
+	@Builder
+	private Exam(String title, LocalDateTime examDateTime,
+			Integer duration, Integer totalScore, String description, Course course) {
+		this.title = title;
+		this.examDateTime = examDateTime;
+		this.duration = duration;
+		this.totalScore = totalScore;
+		this.description = description;
+		this.course = course;
+	}
 
-    public LocalDateTime getEndDateTime() {
+	public LocalDateTime getEndDateTime() {
 		if (examDateTime == null || duration == null) {
 			throw new IllegalStateException("시험 시작 시간 또는 시험 시간이 설정되지 않았습니다.");
 		}
@@ -79,71 +79,72 @@ public class Exam extends BaseTimeEntity {
 		return examDateTime.plusMinutes(duration);
 	}
 
-    public void updateExam(String title, LocalDateTime examDateTime,
-            Integer duration, Integer totalScore, String description) {
-        this.title = title;
-        this.examDateTime = examDateTime;
-        this.duration = duration;
-        this.totalScore = totalScore;
-        this.description = description;
-    }
+	public void updateExam(String title, LocalDateTime examDateTime,
+			Integer duration, Integer totalScore, String description) {
+		this.title = title;
+		this.examDateTime = examDateTime;
+		this.duration = duration;
+		this.totalScore = totalScore;
+		this.description = description;
+	}
 
-    public void addQuestion(ExamQuestion question) {
-        this.questions.add(question);
-        question.setExam(this);
-    }
+	public void addQuestion(ExamQuestion question) {
+		this.questions.add(question);
+		question.setExam(this);
+	}
 
-    public void reorderQuestions(Long questionId, int newNumber) {
-        // 1. 이동할 문제 찾기
-        ExamQuestion targetQuestion = questions.stream()
-                .filter(q -> q.getId().equals(questionId))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("문제를 찾을 수 없습니다. ID: " + questionId));
+	public void reorderQuestions(Long questionId, int newNumber) {
+		// 1. 이동할 문제 찾기
+		ExamQuestion targetQuestion = questions.stream()
+				.filter(q -> q.getId().equals(questionId))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("문제를 찾을 수 없습니다. ID: " + questionId));
 
-        // 2. 현재 문제 번호
-        int currentNumber = targetQuestion.getExamNumber();
+		// 2. 현재 문제 번호
+		int currentNumber = targetQuestion.getExamNumber();
 
-        // 3. 유효성 검사
-        if (newNumber < 1 || newNumber > questions.size()) {
-            throw new IllegalArgumentException("유효하지 않은 문제 번호입니다: " + newNumber);
-        }
+		// 3. 유효성 검사
+		if (newNumber < 1 || newNumber > questions.size()) {
+			throw new IllegalArgumentException("유효하지 않은 문제 번호입니다: " + newNumber);
+		}
 
-        // 4. 문제 번호 재정렬
-        if (currentNumber < newNumber) {
-            // 현재 위치에서 뒤로 이동하는 경우
-            questions.stream()
-                    .filter(q -> q.getExamNumber() > currentNumber && q.getExamNumber() <= newNumber)
-                    .forEach(q -> q.updateExamNumber(q.getExamNumber() - 1));
-        } else if (currentNumber > newNumber) {
-            // 현재 위치에서 앞으로 이동하는 경우
-            questions.stream()
-                    .filter(q -> q.getExamNumber() >= newNumber && q.getExamNumber() < currentNumber)
-                    .forEach(q -> q.updateExamNumber(q.getExamNumber() + 1));
-        }
+		// 4. 문제 번호 재정렬
+		if (currentNumber < newNumber) {
+			// 현재 위치에서 뒤로 이동하는 경우
+			questions.stream()
+					.filter(q -> q.getExamNumber() > currentNumber && q.getExamNumber() <= newNumber)
+					.forEach(q -> q.updateExamNumber(q.getExamNumber() - 1));
+		} else if (currentNumber > newNumber) {
+			// 현재 위치에서 앞으로 이동하는 경우
+			questions.stream()
+					.filter(q -> q.getExamNumber() >= newNumber && q.getExamNumber() < currentNumber)
+					.forEach(q -> q.updateExamNumber(q.getExamNumber() + 1));
+		}
 
-        // 5. 대상 문제의 번호 업데이트
-        targetQuestion.updateExamNumber(newNumber);
-    }
+		// 5. 대상 문제의 번호 업데이트
+		targetQuestion.updateExamNumber(newNumber);
+	}
 
-    public void reorderQuestionsAfterDelete(int deletedNumber) {
-        questions.stream()
-                .filter(q -> q.getExamNumber() > deletedNumber)
-                .forEach(q -> q.updateExamNumber(q.getExamNumber() - 1));
-    }
+	public void reorderQuestionsAfterDelete(int deletedNumber) {
+		questions.stream()
+				.filter(q -> q.getExamNumber() > deletedNumber)
+				.forEach(q -> q.updateExamNumber(q.getExamNumber() - 1));
+	}
 
-    public boolean isBeforeExam() {
+	public boolean isBeforeExam() {
 		if (examDateTime == null) {
 			throw new IllegalStateException("시험 시작 시간이 설정되지 않았습니다.");
 		}
 		return LocalDateTime.now().isBefore(examDateTime);
 	}
-	
+
 	public boolean isAfterExam() {
 		return LocalDateTime.now().isAfter(getEndDateTime());
 	}
-	
+
 	public boolean isDuringExam() {
 		LocalDateTime now = LocalDateTime.now();
 		return !isBeforeExam() && !isAfterExam();
 	}
+
 }

--- a/src/main/java/com/example/epari/exam/dto/common/ExamResultDetailDto.java
+++ b/src/main/java/com/example/epari/exam/dto/common/ExamResultDetailDto.java
@@ -1,0 +1,29 @@
+package com.example.epari.exam.dto.common;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.example.epari.global.common.enums.ExamStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExamResultDetailDto {
+
+	private Long examId;
+
+	private String examTitle;
+
+	private LocalDateTime startTime;
+
+	private LocalDateTime endTime;
+
+	private ExamStatus status;
+
+	private Integer totalScore;
+
+	private List<QuestionResultDto> questionResults;
+
+}

--- a/src/main/java/com/example/epari/exam/dto/common/ExamResultSummaryDto.java
+++ b/src/main/java/com/example/epari/exam/dto/common/ExamResultSummaryDto.java
@@ -1,0 +1,24 @@
+package com.example.epari.exam.dto.common;
+
+import java.time.LocalDateTime;
+
+import com.example.epari.global.common.enums.ExamStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExamResultSummaryDto {
+
+	private String studentName;
+
+	private String studentEmail;
+
+	private ExamStatus status;
+
+	private Integer totalScore;
+
+	private LocalDateTime submittedAt;
+
+}

--- a/src/main/java/com/example/epari/exam/dto/common/QuestionResultDto.java
+++ b/src/main/java/com/example/epari/exam/dto/common/QuestionResultDto.java
@@ -1,0 +1,18 @@
+package com.example.epari.exam.dto.common;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuestionResultDto {
+
+	private Long questionId;
+
+	private String questionTitle;
+
+	private String studentAnswer;
+
+	private Integer score;
+
+}

--- a/src/main/java/com/example/epari/exam/dto/request/ExamRequestDto.java
+++ b/src/main/java/com/example/epari/exam/dto/request/ExamRequestDto.java
@@ -18,16 +18,16 @@ import lombok.Setter;
 public class ExamRequestDto {
 
 	@NotBlank(message = "시험 제목은 필수입니다.")
-    private String title;
-    
-    @NotNull(message = "시험 일시는 필수입니다.")
-    private LocalDateTime examDateTime;
-    
-    @Min(value = 1, message = "시험 시간은 1분 이상이어야 합니다.")
-    private Integer duration;
-    
-    @Min(value = 100, message = "총점은 100점 이상이어야 합니다.")
-    private Integer totalScore;
+	private String title;
+
+	@NotNull(message = "시험 일시는 필수입니다.")
+	private LocalDateTime examDateTime;
+
+	@Min(value = 1, message = "시험 시간은 1분 이상이어야 합니다.")
+	private Integer duration;
+
+	@Min(value = 100, message = "총점은 100점 이상이어야 합니다.")
+	private Integer totalScore;
 
 	private String description;
 

--- a/src/main/java/com/example/epari/exam/service/ExamService.java
+++ b/src/main/java/com/example/epari/exam/service/ExamService.java
@@ -88,8 +88,8 @@ public class ExamService {
 	// 시험 목록 조회
 	public ExamListResponseDto getExams(Long courseId, ExamStatus status, String email, String role) {
 		Course course = courseRepository.findById(courseId)
-            .orElseThrow(() -> new BusinessBaseException(ErrorCode.COURSE_NOT_FOUND));
-		
+				.orElseThrow(() -> new BusinessBaseException(ErrorCode.COURSE_NOT_FOUND));
+
 		List<Exam> exams;
 
 		// 권한에 따른 시험 목록 조회

--- a/src/main/java/com/example/epari/exam/service/ExamSubmissionService.java
+++ b/src/main/java/com/example/epari/exam/service/ExamSubmissionService.java
@@ -4,11 +4,12 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.beans.factory.annotation.Value;
 
 import com.example.epari.course.repository.CourseStudentRepository;
 import com.example.epari.exam.domain.Exam;
@@ -16,14 +17,16 @@ import com.example.epari.exam.domain.ExamQuestion;
 import com.example.epari.exam.domain.ExamResult;
 import com.example.epari.exam.domain.ExamScore;
 import com.example.epari.exam.dto.common.AnswerSubmissionDto;
+import com.example.epari.exam.dto.common.ExamResultDetailDto;
+import com.example.epari.exam.dto.common.ExamResultSummaryDto;
 import com.example.epari.exam.dto.common.ExamSubmissionStatusDto;
+import com.example.epari.exam.dto.common.QuestionResultDto;
 import com.example.epari.exam.repository.ExamQuestionRepository;
 import com.example.epari.exam.repository.ExamRepository;
 import com.example.epari.exam.repository.ExamResultRepository;
 import com.example.epari.global.common.enums.ExamStatus;
 import com.example.epari.global.exception.BusinessBaseException;
 import com.example.epari.global.exception.ErrorCode;
-import com.example.epari.global.validator.CourseAccessValidator;
 import com.example.epari.global.validator.ExamQuestionValidator;
 import com.example.epari.user.domain.Student;
 import com.example.epari.user.repository.StudentRepository;
@@ -78,39 +81,39 @@ public class ExamSubmissionService {
 
 	// 답안 임시 저장
 	public void saveAnswerTemporarily(Long courseId, Long examId, Long questionId,
-        AnswerSubmissionDto answerDto, String studentEmail) {
-    ExamResult examResult = getExamResultInProgress(examId, studentEmail);
-    validateExamTimeRemaining(examResult.getExam());
+			AnswerSubmissionDto answerDto, String studentEmail) {
+		ExamResult examResult = getExamResultInProgress(examId, studentEmail);
+		validateExamTimeRemaining(examResult.getExam());
 
-    // examId로 함께 검증
-    ExamQuestion question = examQuestionRepository
-            .findByExamIdAndId(examId, questionId)
-            .orElseThrow(() -> new BusinessBaseException(ErrorCode.QUESTION_NOT_FOUND));
+		// examId로 함께 검증
+		ExamQuestion question = examQuestionRepository
+				.findByExamIdAndId(examId, questionId)
+				.orElseThrow(() -> new BusinessBaseException(ErrorCode.QUESTION_NOT_FOUND));
 
-    // question이 해당 시험의 문제가 맞는지 한번 더 검증
-    if (!question.getExam().getId().equals(examResult.getExam().getId())) {
-        throw new BusinessBaseException(ErrorCode.UNAUTHORIZED_EXAM_ACCESS);
-    }
+		// question이 해당 시험의 문제가 맞는지 한번 더 검증
+		if (!question.getExam().getId().equals(examResult.getExam().getId())) {
+			throw new BusinessBaseException(ErrorCode.UNAUTHORIZED_EXAM_ACCESS);
+		}
 
-    // 기존 임시 저장된 답안이 있는지 확인
-    Optional<ExamScore> existingScore = examResult.getScores().stream()
-            .filter(score -> score.getQuestion().getId().equals(questionId))
-            .findFirst();
+		// 기존 임시 저장된 답안이 있는지 확인
+		Optional<ExamScore> existingScore = examResult.getScores().stream()
+				.filter(score -> score.getQuestion().getId().equals(questionId))
+				.findFirst();
 
-    if (existingScore.isPresent()) {
-        // 기존 답안 업데이트
-        existingScore.get().updateAnswer(answerDto.getAnswer());
-    } else {
-        // 새로운 답안 생성
-        ExamScore score = ExamScore.builder()
-                .examResult(examResult)
-                .question(question)
-                .studentAnswer(answerDto.getAnswer())
-                .temporary(true)  // 임시저장 표시
-                .build();
-        examResult.addScore(score);
-    }
-}
+		if (existingScore.isPresent()) {
+			// 기존 답안 업데이트
+			existingScore.get().updateAnswer(answerDto.getAnswer());
+		} else {
+			// 새로운 답안 생성
+			ExamScore score = ExamScore.builder()
+					.examResult(examResult)
+					.question(question)
+					.studentAnswer(answerDto.getAnswer())
+					.temporary(true)  // 임시저장 표시
+					.build();
+			examResult.addScore(score);
+		}
+	}
 
 	public void submitAnswer(Long courseId, Long examId, Long questionId,
 			AnswerSubmissionDto answerDto, String studentEmail) {
@@ -184,7 +187,7 @@ public class ExamSubmissionService {
 		Exam exam = examQuestionValidator.validateExamAccess(courseId, examId);
 		ExamResult examResult = examResultRepository.findByExamIdAndStudentEmail(examId, email)
 				.orElseThrow(() -> new BusinessBaseException(ErrorCode.EXAM_RESULT_NOT_FOUND));
-		
+
 		return ExamSubmissionStatusDto.builder()
 				.examId(examId)
 				.status(examResult.getStatus())
@@ -218,7 +221,7 @@ public class ExamSubmissionService {
 	private ExamSubmissionStatusDto createExamSubmissionStatusDto(Exam exam, ExamResult examResult) {
 		LocalDateTime now = LocalDateTime.now();
 		return ExamSubmissionStatusDto.builder()
-				.status(examResult.getStatus())                    
+				.status(examResult.getStatus())
 				.submittedQuestionCount(examResult.getSubmittedQuestionCount())
 				.totalQuestionCount(exam.getQuestions().size())
 				.remainingTimeInMinutes(calculateRemainingTime(now, exam.getEndDateTime()))
@@ -231,6 +234,51 @@ public class ExamSubmissionService {
 			return 0;
 		}
 		return (int)Duration.between(now, endTime).toMinutes();
+	}
+
+	public ExamResultDetailDto getStudentExamResult(Long courseId, Long examId, String studentEmail) {
+		// 1. 시험 결과 조회
+		ExamResult examResult = examResultRepository.findByExamIdAndStudentEmail(examId, studentEmail)
+				.orElseThrow(() -> new BusinessBaseException(ErrorCode.EXAM_RESULT_NOT_FOUND));
+
+		// 2. 시험 정보 조회
+		Exam exam = examRepository.findById(examId)
+				.orElseThrow(() -> new BusinessBaseException(ErrorCode.EXAM_NOT_FOUND));
+
+		// 3. 문제별 답안 조회
+		List<ExamAnswer> answers = examAnswerRepository.findByExamIdAndStudentEmail(examId, studentEmail);
+
+		// 4. DTO 변환
+		List<QuestionResultDto> questionResults = answers.stream()
+				.map(answer -> QuestionResultDto.builder()
+						.questionId(answer.getQuestionId())
+						.questionTitle(answer.getQuestion().getTitle())
+						.studentAnswer(answer.getAnswer())
+						.score(answer.getScore())
+						.build())
+				.collect(Collectors.toList());
+
+		return ExamResultDetailDto.builder()
+				.examId(examId)
+				.examTitle(exam.getTitle())
+				.startTime(examResult.getStartTime())
+				.endTime(examResult.getSubmitTime())
+				.status(examResult.getStatus())
+				.totalScore(examResult.getTotalScore())
+				.questionResults(questionResults)
+				.build();
+	}
+
+	public List<ExamResultSummaryDto> getExamResults(Long courseId, Long examId) {
+		return examResultRepository.findAllByExamId(examId).stream()
+				.map(result -> ExamResultSummaryDto.builder()
+						.studentName(result.getStudent().getName())
+						.studentEmail(result.getStudent().getEmail())
+						.status(result.getStatus())
+						.totalScore(result.getTotalScore())
+						.submittedAt(result.getSubmitTime())
+						.build())
+				.collect(Collectors.toList());
 	}
 
 }

--- a/src/main/java/com/example/epari/global/config/ThymeleafConfig.java
+++ b/src/main/java/com/example/epari/global/config/ThymeleafConfig.java
@@ -17,7 +17,7 @@ public class ThymeleafConfig {
 		SpringTemplateEngine templateEngine = new SpringTemplateEngine();
 
 		templateEngine.setTemplateResolver(emailTemplateResolver());
-		
+
 		return templateEngine;
 	}
 

--- a/src/main/java/com/example/epari/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorCode.java
@@ -49,7 +49,7 @@ public enum ErrorCode {
 	PENDING_APPROVAL(HttpStatus.BAD_REQUEST, "AUTH-020", "가입 승인 대기중입니다."),
 
 	// Student 관련 에러 코드(ST
-    STUDENT_NOT_FOUND(HttpStatus.NOT_FOUND, "STD-001", "학생 정보를 찾을 수 없습니다."),
+	STUDENT_NOT_FOUND(HttpStatus.NOT_FOUND, "STD-001", "학생 정보를 찾을 수 없습니다."),
 
 	// Course 관련 에러 코드 (CRS)
 	COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "CRS-001", "강의를 찾을 수 없습니다."),
@@ -59,9 +59,9 @@ public enum ErrorCode {
 	ASSIGNMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ASM-001", "과제를 찾을 수 없습니다."),
 	SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "ASM-002", "과제 제출물을 찾을 수 없습니다."),
 
-    // Question 관련 에러 코드(EXAM)
-    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QST-001", "문제를 찾을 수 없습니다."),
-    QUESTION_HAS_SUBMISSIONS(HttpStatus.BAD_REQUEST, "QST-002", "답안이 제출된 문제는 삭제할 수 없습니다."),
+	// Question 관련 에러 코드(EXAM)
+	QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QST-001", "문제를 찾을 수 없습니다."),
+	QUESTION_HAS_SUBMISSIONS(HttpStatus.BAD_REQUEST, "QST-002", "답안이 제출된 문제는 삭제할 수 없습니다."),
 
 	// Exam 관련 에러 코드 (EXAM)
 	EXAM_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM-001", "시험을 찾을 수 없습니다."),

--- a/src/main/java/com/example/epari/global/exception/exam/ExamResultNotFoundException.java
+++ b/src/main/java/com/example/epari/global/exception/exam/ExamResultNotFoundException.java
@@ -4,6 +4,7 @@ import com.example.epari.global.exception.BusinessBaseException;
 import com.example.epari.global.exception.ErrorCode;
 
 public class ExamResultNotFoundException extends BusinessBaseException {
+
 	public ExamResultNotFoundException() {
 		super(ErrorCode.EXAM_RESULT_NOT_FOUND);
 	}

--- a/src/main/java/com/example/epari/global/validator/ExamQuestionValidator.java
+++ b/src/main/java/com/example/epari/global/validator/ExamQuestionValidator.java
@@ -7,49 +7,54 @@ import com.example.epari.exam.domain.Exam;
 import com.example.epari.exam.domain.ExamQuestion;
 import com.example.epari.exam.repository.ExamQuestionRepository;
 import com.example.epari.exam.repository.ExamRepository;
+import com.example.epari.exam.repository.ExamResultRepository;
 import com.example.epari.global.exception.BusinessBaseException;
 import com.example.epari.global.exception.ErrorCode;
-import com.example.epari.exam.repository.ExamResultRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class ExamQuestionValidator {
-    private final CourseRepository courseRepository;
-    private final ExamRepository examRepository;
-    private final ExamQuestionRepository examQuestionRepository;
+
+	private final CourseRepository courseRepository;
+
+	private final ExamRepository examRepository;
+
+	private final ExamQuestionRepository examQuestionRepository;
+
 	private final ExamResultRepository examResultRepository;
 
-    public void validateInstructorAccess(Long courseId, String instructorEmail) {
-        if (!courseRepository.existsByCourseIdAndInstructorEmail(courseId, instructorEmail)) {
-            throw new BusinessBaseException(ErrorCode.UNAUTHORIZED_EXAM_ACCESS);
-        }
-    }
+	public void validateInstructorAccess(Long courseId, String instructorEmail) {
+		if (!courseRepository.existsByCourseIdAndInstructorEmail(courseId, instructorEmail)) {
+			throw new BusinessBaseException(ErrorCode.UNAUTHORIZED_EXAM_ACCESS);
+		}
+	}
 
-    public Exam validateExamAccess(Long courseId, Long examId) {
-        return examRepository.findByCourseIdAndId(courseId, examId)
-                .orElseThrow(() -> new BusinessBaseException(ErrorCode.EXAM_NOT_FOUND));
-    }
+	public Exam validateExamAccess(Long courseId, Long examId) {
+		return examRepository.findByCourseIdAndId(courseId, examId)
+				.orElseThrow(() -> new BusinessBaseException(ErrorCode.EXAM_NOT_FOUND));
+	}
 
-    public ExamQuestion validateQuestionAccess(Long examId, Long questionId) {
-        return examQuestionRepository.findByExamIdAndId(examId, questionId)
-                .orElseThrow(() -> new BusinessBaseException(ErrorCode.EXAM_QUESTION_NOT_FOUND));
-    }
+	public ExamQuestion validateQuestionAccess(Long examId, Long questionId) {
+		return examQuestionRepository.findByExamIdAndId(examId, questionId)
+				.orElseThrow(() -> new BusinessBaseException(ErrorCode.EXAM_QUESTION_NOT_FOUND));
+	}
 
 	public void validateExamTime(Exam exam) {
-        if (exam.isBeforeExam()) {
-            throw new BusinessBaseException(ErrorCode.EXAM_NOT_STARTED);
-        }
-        if (exam.isAfterExam()) {
-            throw new BusinessBaseException(ErrorCode.EXAM_ALREADY_ENDED);
-        }
-    }
+		if (exam.isBeforeExam()) {
+			throw new BusinessBaseException(ErrorCode.EXAM_NOT_STARTED);
+		}
+		if (exam.isAfterExam()) {
+			throw new BusinessBaseException(ErrorCode.EXAM_ALREADY_ENDED);
+		}
+	}
 
-    public void validateNotAlreadyStarted(Long examId, String studentEmail) {
-        examResultRepository.findByExamIdAndStudentEmail(examId, studentEmail)
-                .ifPresent(result -> {
-                    throw new BusinessBaseException(ErrorCode.EXAM_ALREADY_STARTED);
-                });
-    }
+	public void validateNotAlreadyStarted(Long examId, String studentEmail) {
+		examResultRepository.findByExamIdAndStudentEmail(examId, studentEmail)
+				.ifPresent(result -> {
+					throw new BusinessBaseException(ErrorCode.EXAM_ALREADY_STARTED);
+				});
+	}
+
 }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
- Closes #100

## 변경 사항
<!-- 이 PR에서 변경된 주요 내용을 설명해주세요.
     변경사항이 여러 개일 경우, 주요 내용과 하위 항목을 구분하여 작성해주세요. -->
1. **시험 결과 조회 로직 수정**
   - `getStudentExamResult` 메서드 변경
     - `answer.getQuestionId()` 호출 방식을 `examQuestionRepository`의 `findById` 메서드로 교체
     - 해당 문제를 찾지 못한 경우 예외를 던지도록 처리 (`QUESTION_NOT_FOUND`)

2. **ExamResultDetailDto 반환 개선**
   - 문제별 결과 생성 시 `QuestionResultDto` 리스트를 생성하는 로직 수정
   - `examQuestion` 객체를 직접 활용하여 데이터 생성

3. **테스트 안정성 강화**
   - 불필요한 객체 참조 제거

## 스크린샷
<!-- (선택) 주요 변경사항(기능 구현 화면, 테스트 결과 등)에 대한 이미지를 삽입해주세요. -->
|기능|스크린샷|
|---|---|
|시험 모든 학생 결과 조회|![스크린샷 2024-11-20 오후 9 09 40](https://github.com/user-attachments/assets/9833713c-dc1b-4eb2-b641-c841971fc78d)|
|학생의 본인 성적 조회|![스크린샷 2024-11-20 오후 9 11 00](https://github.com/user-attachments/assets/70cb4300-5427-436a-8001-2cd9158f2bf4)|


## 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항들입니다. -->
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
<!-- 리뷰어에게 전달할 추가 정보가 있다면 여기에 적어주세요. -->

## 추후 업무
<!-- 추후 진행될 과제에 대해 적어주세요. -->
- [ ] `ExamResult` 검증 로직 리팩토링
