### PR TITLE
[FEAT] 관리자용 강의 관리 시스템 구현

### DIFF
--- a/src/main/java/com/example/epari/admin/controller/AdminCourseController.java
+++ b/src/main/java/com/example/epari/admin/controller/AdminCourseController.java
@@ -2,7 +2,6 @@ package com.example.epari.admin.controller;
 
 import java.util.List;
 
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.epari.admin.dto.AdminCourseListResponseDto;
 import com.example.epari.admin.dto.AdminCourseRequestDto;
 import com.example.epari.admin.dto.CourseSearchResponseDTO;
 import com.example.epari.admin.service.AdminCourseService;
@@ -58,6 +58,14 @@ public class AdminCourseController {
 		log.info("Course created successfully - id: {}", savedCourseId);
 
 		return ResponseEntity.ok(savedCourseId);
+	}
+
+	/**
+	 * 모든 강의 목록 조회
+	 */
+	@GetMapping
+	public ResponseEntity<List<AdminCourseListResponseDto>> getCourses() {
+		return ResponseEntity.ok(adminCourseService.getCourses());
 	}
 
 }

--- a/src/main/java/com/example/epari/admin/controller/AdminCourseController.java
+++ b/src/main/java/com/example/epari/admin/controller/AdminCourseController.java
@@ -2,21 +2,28 @@ package com.example.epari.admin.controller;
 
 import java.util.List;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.epari.admin.dto.AdminCourseRequestDto;
 import com.example.epari.admin.dto.CourseSearchResponseDTO;
 import com.example.epari.admin.service.AdminCourseService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 관리자를 위한 REST API 컨트롤러
  * 강의 관리
  */
+@Slf4j
 @RestController
 @RequestMapping("/api/admin/courses")
 @RequiredArgsConstructor
@@ -31,6 +38,26 @@ public class AdminCourseController {
 	public ResponseEntity<List<CourseSearchResponseDTO>> searchCourses(
 			@RequestParam(required = false) String keyword) {
 		return ResponseEntity.ok(adminCourseService.searchCourses(keyword));
+	}
+
+	/**
+	 * 강의 생성
+	 */
+	@PostMapping
+	public ResponseEntity<Long> createCourse(
+			@Validated @ModelAttribute AdminCourseRequestDto request) {
+		if (!request.isValidDateRange()) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		log.info("Course creation request received - name: {}, instructor: {}",
+				request.getName(), request.getInstructorId());
+
+		Long savedCourseId = adminCourseService.createCourse(request);
+
+		log.info("Course created successfully - id: {}", savedCourseId);
+
+		return ResponseEntity.ok(savedCourseId);
 	}
 
 }

--- a/src/main/java/com/example/epari/admin/controller/AdminCourseStudentController.java
+++ b/src/main/java/com/example/epari/admin/controller/AdminCourseStudentController.java
@@ -1,0 +1,63 @@
+package com.example.epari.admin.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.epari.admin.dto.AvailableStudentResponseDTO;
+import com.example.epari.admin.dto.CourseStudentResponseDTO;
+import com.example.epari.admin.dto.CourseStudentUpdateRequestDTO;
+import com.example.epari.admin.service.AdminCourseStudentService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 관리자를 위한 REST API 컨트롤러
+ * 강의와 학생 관련 엔드포인트 관리
+ */
+@RestController
+@RequestMapping("/api/admin/courses/{courseId}/students")
+@RequiredArgsConstructor
+public class AdminCourseStudentController {
+
+	private final AdminCourseStudentService courseStudentService;
+
+	/**
+	 * 강의에 등록된 수강생 목록 조회
+	 */
+	@GetMapping
+	public ResponseEntity<List<CourseStudentResponseDTO>> getEnrolledStudents(
+			@PathVariable Long courseId) {
+		return ResponseEntity.ok(courseStudentService.getEnrolledStudents(courseId));
+	}
+
+	/**
+	 * 강의에 등록 가능한 수강생 목록 조회
+	 */
+	@GetMapping("/available")
+	public ResponseEntity<List<AvailableStudentResponseDTO>> getAvailableStudents(
+			@PathVariable Long courseId,
+			@RequestParam(required = false) String keyword) {
+		return ResponseEntity.ok(courseStudentService.getAvailableStudents(courseId, keyword));
+	}
+
+	/**
+	 * 수강생 목록 업데이트
+	 */
+	@PutMapping
+	public ResponseEntity<Void> updateEnrolledStudents(
+			@PathVariable Long courseId,
+			@RequestBody CourseStudentUpdateRequestDTO request) {
+		courseStudentService.updateEnrolledStudents(courseId, request);
+
+		return ResponseEntity.ok().build();
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/controller/AdminInstructorController.java
+++ b/src/main/java/com/example/epari/admin/controller/AdminInstructorController.java
@@ -1,0 +1,40 @@
+package com.example.epari.admin.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.epari.admin.dto.InstructorSearchResponseDTO;
+import com.example.epari.admin.service.AdminInstructorService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 관리자를 위한 REST API 컨트롤러
+ * 강사 관리
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/instructors")
+@RequiredArgsConstructor
+public class AdminInstructorController {
+
+	private final AdminInstructorService adminInstructorService;
+
+	/**
+	 * 이메일 기반 강사 검색 엔드포인트
+	 */
+	@GetMapping("/search")
+	public ResponseEntity<List<InstructorSearchResponseDTO>> searchInstructors(
+			@RequestParam(required = false) String email) {
+		log.info("Instructor search request received with email: {}", email);
+
+		return ResponseEntity.ok(adminInstructorService.searchInstructors(email));
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/dto/AdminCourseListResponseDto.java
+++ b/src/main/java/com/example/epari/admin/dto/AdminCourseListResponseDto.java
@@ -1,0 +1,53 @@
+package com.example.epari.admin.dto;
+
+import java.time.LocalDate;
+
+import lombok.Getter;
+
+/**
+ * 강의 정보 목록을 담는 응답 DTO
+ */
+@Getter
+public class AdminCourseListResponseDto {
+
+	private final Long id;
+
+	private final String name;
+
+	private final String classroom;
+
+	private final InstructorInfo instructor;
+
+	private final LocalDate startDate;
+
+	private final LocalDate endDate;
+
+	private final int studentCount;
+
+	public AdminCourseListResponseDto(Long id, String name, String classroom,
+			Long instructorId, String instructorName,
+			LocalDate startDate, LocalDate endDate, Long studentCount) {
+		this.id = id;
+		this.name = name;
+		this.classroom = classroom;
+		this.instructor = new InstructorInfo(instructorId, instructorName);
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.studentCount = studentCount.intValue();
+	}
+
+	@Getter
+	public static class InstructorInfo {
+
+		private final Long id;
+
+		private final String name;
+
+		public InstructorInfo(Long id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/dto/AdminCourseRequestDto.java
+++ b/src/main/java/com/example/epari/admin/dto/AdminCourseRequestDto.java
@@ -1,0 +1,64 @@
+package com.example.epari.admin.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 강의 생성 요청 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminCourseRequestDto {
+
+	@NotBlank(message = "강의명은 필수입니다.")
+	private String name;
+
+	@NotNull(message = "시작일은 필수입니다.")
+	private LocalDate startDate;
+
+	@NotNull(message = "종료일은 필수입니다.")
+	private LocalDate endDate;
+
+	@NotBlank(message = "강의실은 필수입니다.")
+	private String classroom;
+
+	@NotNull(message = "강사 ID는 필수입니다.")
+	private Long instructorId;
+
+	private MultipartFile courseImage;  // 강의 이미지 (선택)
+
+	// 커리큘럼 정보
+	@NotNull(message = "커리큘럼은 필수입니다.")
+	private List<CurriculumInfo> curriculums;
+
+	// 날짜 유효성 검증
+	public boolean isValidDateRange() {
+		return !startDate.isAfter(endDate);
+	}
+
+	@Getter
+	@Setter
+	public static class CurriculumInfo {
+
+		@NotNull(message = "강의 날짜는 필수입니다.")
+		private LocalDate date;
+
+		@NotBlank(message = "강의 주제는 필수입니다.")
+		private String topic;
+
+		private String description;  // 상세 설명 (선택)
+
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/dto/AvailableStudentResponseDTO.java
+++ b/src/main/java/com/example/epari/admin/dto/AvailableStudentResponseDTO.java
@@ -1,0 +1,23 @@
+package com.example.epari.admin.dto;
+
+import lombok.Getter;
+
+/**
+ * 강의에 등록 가능한 학생 정보를 담는 DTO
+ */
+@Getter
+public class AvailableStudentResponseDTO {
+
+	private final Long id;
+
+	private final String name;
+
+	private final String email;
+
+	public AvailableStudentResponseDTO(Long id, String name, String email) {
+		this.id = id;
+		this.name = name;
+		this.email = email;
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/dto/CourseStudentResponseDTO.java
+++ b/src/main/java/com/example/epari/admin/dto/CourseStudentResponseDTO.java
@@ -1,0 +1,25 @@
+package com.example.epari.admin.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 학생 정보를 담는 응답 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourseStudentResponseDTO {
+
+	private Long id;
+
+	private String name;
+
+	private String email;
+
+	private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/example/epari/admin/dto/CourseStudentUpdateRequestDTO.java
+++ b/src/main/java/com/example/epari/admin/dto/CourseStudentUpdateRequestDTO.java
@@ -1,0 +1,21 @@
+package com.example.epari.admin.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 수강생 목록 업데이트 요청을 담는 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourseStudentUpdateRequestDTO {
+
+	@NotEmpty(message = "수강생 목록은 비어있을 수 없습니다.")
+	private List<Long> studentIds;
+
+}

--- a/src/main/java/com/example/epari/admin/dto/InstructorSearchResponseDTO.java
+++ b/src/main/java/com/example/epari/admin/dto/InstructorSearchResponseDTO.java
@@ -1,0 +1,23 @@
+package com.example.epari.admin.dto;
+
+import lombok.Getter;
+
+/**
+ * 강사 검색 결과를 담는 응답 DTO
+ */
+@Getter
+public class InstructorSearchResponseDTO {
+
+	private final Long id;
+
+	private final String name;
+
+	private final String email;
+
+	public InstructorSearchResponseDTO(Long id, String name, String email) {
+		this.id = id;
+		this.name = name;
+		this.email = email;
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/repository/AdminCourseRepository.java
+++ b/src/main/java/com/example/epari/admin/repository/AdminCourseRepository.java
@@ -1,0 +1,58 @@
+package com.example.epari.admin.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.example.epari.admin.dto.AdminCourseListResponseDto;
+import com.example.epari.admin.dto.CourseSearchResponseDTO;
+import com.example.epari.course.domain.Course;
+
+/**
+ * 관리자 - 강의 정보에 대한 데이터베이스 접근을 담당하는 레포지토리 인터페이스
+ */
+public interface AdminCourseRepository extends JpaRepository<Course, Long> {
+
+	/**
+	 * 모든 강의 목록 조회
+	 */
+	@Query("""
+			SELECT new com.example.epari.admin.dto.AdminCourseListResponseDto(
+			    c.id, c.name, c.classroom,
+			    i.id, u.name,
+			    c.startDate, c.endDate,
+			    count(cs)
+			)
+			FROM Course c
+			JOIN c.instructor i
+			JOIN BaseUser u ON u.id = i.id
+			LEFT JOIN c.courseStudents cs
+			GROUP BY c.id, c.name, c.classroom, i.id, u.name, c.startDate, c.endDate
+			ORDER BY c.startDate DESC
+			""")
+	List<AdminCourseListResponseDto> findAllWithStudentCount();
+
+	/**
+	 * 키워드를 기반으로 강의 정보를 DTO로 직접 조회하는 쿼리 메서드
+	 * - 키워드가 없으면 전체 조회
+	 * - 필요한 컬럼만 선택적으로 조회
+	 * - new 연산자로 DTO 직접 매핑
+	 */
+	@Query("""
+			    SELECT new com.example.epari.admin.dto.CourseSearchResponseDTO(
+			        c.id,
+			        c.name,
+			        i.name
+			    )
+			    FROM Course c
+			    LEFT JOIN c.instructor i
+			    WHERE (:keyword IS NULL OR
+			           :keyword = '' OR
+			           LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')))
+			    ORDER BY c.name ASC
+			""")
+	List<CourseSearchResponseDTO> searchCoursesWithDTO(@Param("keyword") String keyword);
+
+}

--- a/src/main/java/com/example/epari/admin/repository/AdminCourseStudentRepository.java
+++ b/src/main/java/com/example/epari/admin/repository/AdminCourseStudentRepository.java
@@ -1,9 +1,10 @@
 package com.example.epari.admin.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 import java.util.Set;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.example.epari.admin.dto.CourseStudentResponseDTO;
 import com.example.epari.course.domain.CourseStudent;
@@ -28,9 +29,10 @@ public interface AdminCourseStudentRepository extends JpaRepository<CourseStuden
 			WHERE cs.course.id = :courseId
 			ORDER BY cs.createdAt DESC
 			""")
-    List<CourseStudentResponseDTO> findEnrolledStudentsByCourseId(Long courseId);
+	List<CourseStudentResponseDTO> findEnrolledStudentsByCourseId(Long courseId);
 
-    void deleteByCourseIdAndStudentIdIn(Long courseId, Set<Long> studentIds);
+	void deleteByCourseIdAndStudentIdIn(Long courseId, Set<Long> studentIds);
 
-    List<CourseStudent> findByCourseId(Long courseId);
+	List<CourseStudent> findByCourseId(Long courseId);
+
 }

--- a/src/main/java/com/example/epari/admin/repository/AdminCourseStudentRepository.java
+++ b/src/main/java/com/example/epari/admin/repository/AdminCourseStudentRepository.java
@@ -1,0 +1,36 @@
+package com.example.epari.admin.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import java.util.List;
+import java.util.Set;
+
+import com.example.epari.admin.dto.CourseStudentResponseDTO;
+import com.example.epari.course.domain.CourseStudent;
+
+/**
+ * 관리자 - 강의와 학생 관련 정보에 대한 데이터베이스 접근을 담당하는 레포지토리 인터페이스
+ */
+public interface AdminCourseStudentRepository extends JpaRepository<CourseStudent, Long> {
+
+	/**
+	 * 강의를 수강하는 학생 목록 조회
+	 */
+	@Query("""
+			SELECT new com.example.epari.admin.dto.CourseStudentResponseDTO(
+			    s.id,
+			    s.name,
+			    s.email,
+			    cs.createdAt
+			)
+			FROM CourseStudent cs
+			JOIN cs.student s
+			WHERE cs.course.id = :courseId
+			ORDER BY cs.createdAt DESC
+			""")
+    List<CourseStudentResponseDTO> findEnrolledStudentsByCourseId(Long courseId);
+
+    void deleteByCourseIdAndStudentIdIn(Long courseId, Set<Long> studentIds);
+
+    List<CourseStudent> findByCourseId(Long courseId);
+}

--- a/src/main/java/com/example/epari/admin/repository/AdminInstructorRepository.java
+++ b/src/main/java/com/example/epari/admin/repository/AdminInstructorRepository.java
@@ -1,0 +1,36 @@
+package com.example.epari.admin.repository;
+
+import com.example.epari.admin.dto.InstructorSearchResponseDTO;
+import com.example.epari.user.domain.Instructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+/**
+ * 관리자 - 강사 정보에 대한 데이터베이스 접근을 담당하는 레포지토리 인터페이스
+ */
+public interface AdminInstructorRepository extends JpaRepository<Instructor, Long> {
+
+    /**
+     * 이메일로 강사를 검색하는 쿼리 메서드
+     * - 이메일이 비어있으면 전체 조회
+     * - LIKE 검색으로 부분 일치도 허용
+     * - 필요한 필드만 DTO로 직접 매핑
+     */
+    @Query("""
+            SELECT new com.example.epari.admin.dto.InstructorSearchResponseDTO(
+                i.id,
+                u.name,
+                u.email
+            )
+            FROM Instructor i
+            JOIN BaseUser u ON u.id = i.id
+            WHERE (:email IS NULL OR
+                   :email = '' OR
+                   LOWER(u.email) LIKE LOWER(CONCAT('%', :email, '%')))
+            ORDER BY u.name ASC
+            """)
+    List<InstructorSearchResponseDTO> searchInstructorsWithDTO(@Param("email") String email);
+}

--- a/src/main/java/com/example/epari/admin/repository/AdminStudentRepository.java
+++ b/src/main/java/com/example/epari/admin/repository/AdminStudentRepository.java
@@ -1,0 +1,46 @@
+package com.example.epari.admin.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.example.epari.admin.dto.AvailableStudentResponseDTO;
+import com.example.epari.user.domain.Student;
+
+import java.util.List;
+
+/**
+ * 관리자 - 학생 정보에 대한 데이터베이스 접근을 담당하는 레포지토리 인터페이스
+ */
+public interface AdminStudentRepository extends JpaRepository<Student, Long> {
+
+    /**
+     * 특정 강의에 등록 가능한 학생 목록을 조회
+     * - 해당 강의에 이미 등록된 학생은 제외
+     * - keyword로 이름 또는 이메일 검색 가능
+     * - STUDENT 그룹에 속한 사용자만 조회
+     */
+    @Query("""
+        SELECT new com.example.epari.admin.dto.AvailableStudentResponseDTO(
+            s.id,
+            u.name,
+            u.email
+        )
+        FROM Student s
+        JOIN BaseUser u ON u.id = s.id
+        WHERE s.id NOT IN (
+            SELECT cs.student.id
+            FROM CourseStudent cs
+            WHERE cs.course.id = :courseId
+        )
+        AND (:keyword IS NULL OR :keyword = ''
+            OR LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+            OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%')))
+        AND u.role = 'STUDENT'
+        ORDER BY u.name ASC
+        """)
+    List<AvailableStudentResponseDTO> findAvailableStudentsForCourse(
+        @Param("courseId") Long courseId,
+        @Param("keyword") String keyword
+    );
+}

--- a/src/main/java/com/example/epari/admin/repository/AdminStudentRepository.java
+++ b/src/main/java/com/example/epari/admin/repository/AdminStudentRepository.java
@@ -21,24 +21,24 @@ public interface AdminStudentRepository extends JpaRepository<Student, Long> {
      * - STUDENT 그룹에 속한 사용자만 조회
      */
     @Query("""
-        SELECT new com.example.epari.admin.dto.AvailableStudentResponseDTO(
-            s.id,
-            u.name,
-            u.email
-        )
-        FROM Student s
-        JOIN BaseUser u ON u.id = s.id
-        WHERE s.id NOT IN (
-            SELECT cs.student.id
-            FROM CourseStudent cs
-            WHERE cs.course.id = :courseId
-        )
-        AND (:keyword IS NULL OR :keyword = ''
-            OR LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
-            OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%')))
-        AND u.role = 'STUDENT'
-        ORDER BY u.name ASC
-        """)
+            SELECT new com.example.epari.admin.dto.AvailableStudentResponseDTO(
+                s.id,
+                u.name,
+                u.email
+            )
+            FROM Student s
+            JOIN BaseUser u ON u.id = s.id
+            WHERE s.id NOT IN (
+                SELECT cs.student.id
+                FROM CourseStudent cs
+                WHERE cs.course.id = :courseId
+            )
+            AND (:keyword IS NULL OR :keyword = ''
+                OR LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%')))
+            AND u.role = 'STUDENT'
+            ORDER BY u.name ASC
+            """)
     List<AvailableStudentResponseDTO> findAvailableStudentsForCourse(
         @Param("courseId") Long courseId,
         @Param("keyword") String keyword

--- a/src/main/java/com/example/epari/admin/service/AdminCourseStudentService.java
+++ b/src/main/java/com/example/epari/admin/service/AdminCourseStudentService.java
@@ -1,0 +1,97 @@
+package com.example.epari.admin.service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.epari.admin.dto.AvailableStudentResponseDTO;
+import com.example.epari.admin.dto.CourseStudentResponseDTO;
+import com.example.epari.admin.dto.CourseStudentUpdateRequestDTO;
+import com.example.epari.admin.exception.CourseNotFoundException;
+import com.example.epari.admin.repository.AdminCourseStudentRepository;
+import com.example.epari.admin.repository.AdminStudentRepository;
+import com.example.epari.course.domain.Course;
+import com.example.epari.course.domain.CourseStudent;
+import com.example.epari.course.repository.CourseRepository;
+import com.example.epari.user.domain.Student;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 관리자가 강의와 학생 관련 정보를 관리하는 비즈니스 로직을 처리하는 서비스 클래스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminCourseStudentService {
+
+	private final AdminCourseStudentRepository courseStudentRepository;
+
+	private final AdminStudentRepository studentRepository;
+
+	private final CourseRepository courseRepository;
+
+	/**
+	 * 강의에 등록된 수강생 목록 조회
+	 */
+	public List<CourseStudentResponseDTO> getEnrolledStudents(Long courseId) {
+		return courseStudentRepository.findEnrolledStudentsByCourseId(courseId);
+	}
+
+	/**
+	 * 강의에 등록 가능한 수강생 목록 조회
+	 */
+	public List<AvailableStudentResponseDTO> getAvailableStudents(Long courseId, String keyword) {
+		return studentRepository.findAvailableStudentsForCourse(courseId, keyword);
+	}
+
+	/**
+	 * 수강생 목록 업데이트
+	 */
+	@Transactional
+	@CacheEvict(value = "courses", allEntries = true)
+	public void updateEnrolledStudents(Long courseId, CourseStudentUpdateRequestDTO request) {
+		Course course = courseRepository.findById(courseId)
+				.orElseThrow(CourseNotFoundException::new);
+
+		// 1. 현재 등록된 수강생 ID 집합
+		Set<Long> currentStudentIds = courseStudentRepository
+				.findByCourseId(courseId)
+				.stream()
+				.map(cs -> cs.getStudent().getId())
+				.collect(Collectors.toSet());
+
+		// 2. 새로운 수강생 ID 집합
+		Set<Long> newStudentIds = new HashSet<>(request.getStudentIds());
+
+		// 3. 추가될 학생들 계산 (새 목록에만 있는 ID)
+		Set<Long> toAdd = newStudentIds.stream()
+				.filter(id -> !currentStudentIds.contains(id))
+				.collect(Collectors.toSet());
+
+		// 4. 제거될 학생들 계산 (기존 목록에만 있는 ID)
+		Set<Long> toRemove = currentStudentIds.stream()
+				.filter(id -> !newStudentIds.contains(id))
+				.collect(Collectors.toSet());
+
+		// 5. 제거 처리
+		if (!toRemove.isEmpty()) {
+			courseStudentRepository.deleteByCourseIdAndStudentIdIn(courseId, toRemove);
+		}
+
+		// 6. 추가 처리
+		if (!toAdd.isEmpty()) {
+			List<Student> studentsToAdd = studentRepository.findAllById(toAdd);
+			List<CourseStudent> newEnrollments = studentsToAdd.stream()
+					.map(student -> new CourseStudent(course, student))
+					.collect(Collectors.toList());
+			courseStudentRepository.saveAll(newEnrollments);
+		}
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/service/AdminInstructorService.java
+++ b/src/main/java/com/example/epari/admin/service/AdminInstructorService.java
@@ -1,0 +1,41 @@
+package com.example.epari.admin.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.epari.admin.dto.InstructorSearchResponseDTO;
+import com.example.epari.admin.repository.AdminInstructorRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 관리자가 강사를 관리하는 비즈니스 로직을 처리하는 서비스 클래스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminInstructorService {
+
+	private final AdminInstructorRepository instructorRepository;
+
+	/**
+	 * 이메일 기반 강사 검색 메서드
+	 *
+	 * @param email 검색할 이메일 (null 또는 빈 문자열이면 전체 검색)
+	 * @return 검색된 강사 목록
+	 */
+	public List<InstructorSearchResponseDTO> searchInstructors(String email) {
+		log.info("Searching instructors with email: {}", email);
+
+		List<InstructorSearchResponseDTO> instructors = instructorRepository.searchInstructorsWithDTO(email);
+
+		log.info("Found {} instructors", instructors.size());
+
+		return instructors;
+	}
+
+}

--- a/src/main/java/com/example/epari/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/epari/course/repository/CourseRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.example.epari.admin.dto.CourseSearchResponseDTO;
 import com.example.epari.course.domain.Course;
 
 /**
@@ -60,26 +59,5 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 	boolean existsByCourseIdAndStudentEmail(
 			@Param("courseId") Long courseId,
 			@Param("studentEmail") String studentEmail);
-
-	/**
-	 * 키워드를 기반으로 강의 정보를 DTO로 직접 조회하는 쿼리 메서드
-	 * - 키워드가 없으면 전체 조회
-	 * - 필요한 컬럼만 선택적으로 조회
-	 * - new 연산자로 DTO 직접 매핑
-	 */
-	@Query("""
-			    SELECT new com.example.epari.admin.dto.CourseSearchResponseDTO(
-			        c.id,
-			        c.name,
-			        i.name
-			    )
-			    FROM Course c
-			    LEFT JOIN c.instructor i
-			    WHERE (:keyword IS NULL OR
-			           :keyword = '' OR
-			           LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')))
-			    ORDER BY c.name ASC
-			""")
-	List<CourseSearchResponseDTO> searchCoursesWithDTO(@Param("keyword") String keyword);
 
 }

--- a/src/main/java/com/example/epari/global/config/RedisConfig.java
+++ b/src/main/java/com/example/epari/global/config/RedisConfig.java
@@ -135,6 +135,7 @@ public class RedisConfig {
 
 		// 캐시별 설정 추가
 		configMap.put("curriculums", defaultCacheConfig.entryTtl(CachingTTL.CURRICULUM));
+		configMap.put("courses", defaultCacheConfig.entryTtl(CachingTTL.COURSE_LIST));
 
 		return configMap;
 	}
@@ -160,6 +161,8 @@ public class RedisConfig {
 	private static class CachingTTL {
 
 		public static final Duration CURRICULUM = Duration.ofHours(12);
+
+		public static final Duration COURSE_LIST = Duration.ofHours(3); // 강의 목록 캐시
 
 	}
 

--- a/src/main/java/com/example/epari/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/epari/global/exception/ErrorCode.java
@@ -48,8 +48,11 @@ public enum ErrorCode {
 	SIGNUP_FAILED(HttpStatus.BAD_REQUEST, "AUTH-019", "회원가입 처리 중 오류가 발생했습니다."),
 	PENDING_APPROVAL(HttpStatus.BAD_REQUEST, "AUTH-020", "가입 승인 대기중입니다."),
 
-	// Student 관련 에러 코드(ST
+	// Student 관련 에러 코드(STD)
 	STUDENT_NOT_FOUND(HttpStatus.NOT_FOUND, "STD-001", "학생 정보를 찾을 수 없습니다."),
+
+	// Instructor 관련 에러 코드(IST)
+	INSTRUCTOR_NOT_FOUND(HttpStatus.NOT_FOUND, "IST-001", "강사 정보를 찾을 수 없습니다."),
 
 	// Course 관련 에러 코드 (CRS)
 	COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "CRS-001", "강의를 찾을 수 없습니다."),
@@ -97,10 +100,10 @@ public enum ErrorCode {
 
 	// 채점 관련 에러 코드 (GRD)
 	EXAM_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "GRD-001", "제출되지 않은 시험은 채점할 수 없습니다."),
-    EXAM_ALREADY_GRADED(HttpStatus.BAD_REQUEST, "GRD-002", "이미 채점이 완료된 시험입니다."),
-    GRADING_IN_PROGRESS(HttpStatus.BAD_REQUEST, "GRD-003", "채점이 진행 중인 시험입니다."),
-    INVALID_SCORE_VALUE(HttpStatus.BAD_REQUEST, "GRD-004", "유효하지 않은 점수입니다."),
-    GRADING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "GRD-005", "채점 처리 중 오류가 발생했습니다.");
+	EXAM_ALREADY_GRADED(HttpStatus.BAD_REQUEST, "GRD-002", "이미 채점이 완료된 시험입니다."),
+	GRADING_IN_PROGRESS(HttpStatus.BAD_REQUEST, "GRD-003", "채점이 진행 중인 시험입니다."),
+	INVALID_SCORE_VALUE(HttpStatus.BAD_REQUEST, "GRD-004", "유효하지 않은 점수입니다."),
+	GRADING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "GRD-005", "채점 처리 중 오류가 발생했습니다.");
 
 	private final HttpStatus status;
 


### PR DESCRIPTION
## 관련 이슈
- Closes #104 

## 변경 사항
1. 강의 관리 기능 구현
   - 강의 생성 및 조회 기능
   - 강의 이미지 업로드 기능
   - 커리큘럼 관리 기능
2. 강사 관리 기능 구현
   - 이메일 기반 강사 검색 기능
3. 수강생 관리 기능 구현
   - 수강생 목록 조회 및 업데이트 기능
4. 데이터 접근 계층 구현
   - 레포지토리 인터페이스 구현
   - DTO 구현
5. 캐시 설정 적용

## 스크린샷
|기능|스크린샷|
|---|---|
|강의 관리 화면|![image](https://github.com/user-attachments/assets/737440f1-ce03-4f25-9000-b0006a04b564)|
|강의 생성 화면|![image](https://github.com/user-attachments/assets/bed71e52-24f9-48f6-916d-d6bdf6398376)|
|수강생 관리 화면|![image](https://github.com/user-attachments/assets/ea4aa57b-846c-4edb-ac04-2f1f3ac3c382)|

## 체크리스트
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
- 강의 목록 캐시 설정 적용으로 조회 성능 개선

## 추후 업무
- [ ] 강의 수정/삭제 기능 구현
- [ ] 대시보드 기능 구현
- [ ] 공지사항 작성 기능 구현