### PR TITLE
[FEAT] 관리자 - 강의 상세 조회, 수정 엔드포인트 구현

### DIFF
--- a/src/main/java/com/example/epari/admin/controller/AdminCourseController.java
+++ b/src/main/java/com/example/epari/admin/controller/AdminCourseController.java
@@ -6,13 +6,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.epari.admin.dto.AdminCourseDetailResponseDto;
 import com.example.epari.admin.dto.AdminCourseListResponseDto;
 import com.example.epari.admin.dto.AdminCourseRequestDto;
+import com.example.epari.admin.dto.AdminCourseUpdateRequestDto;
 import com.example.epari.admin.dto.CourseSearchResponseDTO;
 import com.example.epari.admin.service.AdminCourseService;
 
@@ -66,6 +70,46 @@ public class AdminCourseController {
 	@GetMapping
 	public ResponseEntity<List<AdminCourseListResponseDto>> getCourses() {
 		return ResponseEntity.ok(adminCourseService.getCourses());
+	}
+
+	/**
+	 * 강의 상세 정보 조회
+	 */
+	@GetMapping("/{courseId}")
+	public ResponseEntity<AdminCourseDetailResponseDto> getCourseDetail(@PathVariable Long courseId) {
+		log.info("Course detail request received - courseId: {}", courseId);
+
+		AdminCourseDetailResponseDto courseDetail = adminCourseService.getCourseDetail(courseId);
+
+		log.info("Course detail retrieved successfully - courseId: {}", courseId);
+
+		return ResponseEntity.ok(courseDetail);
+	}
+
+	/**
+	 * 강의 수정
+	 */
+	@PutMapping("/{courseId}")
+	public ResponseEntity<Void> updateCourse(
+			@PathVariable Long courseId,
+			@Validated @ModelAttribute AdminCourseUpdateRequestDto request) {
+
+		if (!request.isValidDateRange()) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		if (!request.isAllCurriculumDatesValid()) {
+			return ResponseEntity.badRequest().build();
+		}
+
+		log.info("Course update request received - courseId: {}, name: {}, instructor: {}",
+				courseId, request.getName(), request.getInstructorId());
+
+		adminCourseService.updateCourse(courseId, request);
+
+		log.info("Course updated successfully - courseId: {}", courseId);
+
+		return ResponseEntity.ok().build();
 	}
 
 }

--- a/src/main/java/com/example/epari/admin/dto/AdminCourseDetailResponseDto.java
+++ b/src/main/java/com/example/epari/admin/dto/AdminCourseDetailResponseDto.java
@@ -1,0 +1,45 @@
+package com.example.epari.admin.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 강의 상세 정보 응답 DTO
+ */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AdminCourseDetailResponseDto {
+
+	private final Long id;
+
+	private final String name;
+
+	private final String classroom;
+
+	private final InstructorInfo instructor;
+
+	private final LocalDate startDate;
+
+	private final LocalDate endDate;
+
+	private final String imageUrl;
+
+	private final int studentCount;
+
+	private final List<CurriculumDetailDto> curriculums;
+
+	public static AdminCourseDetailResponseDto of(Long id, String name, String classroom, Long instructorId,
+			String instructorName, LocalDate startDate, LocalDate endDate, String imageUrl, int studentCount,
+			List<CurriculumDetailDto> curriculums
+	) {
+		return new AdminCourseDetailResponseDto(
+				id, name, classroom, new InstructorInfo(instructorId, instructorName),
+				startDate, endDate, imageUrl, studentCount, curriculums
+		);
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/dto/AdminCourseRequestDto.java
+++ b/src/main/java/com/example/epari/admin/dto/AdminCourseRequestDto.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -39,6 +40,7 @@ public class AdminCourseRequestDto {
 	private MultipartFile courseImage;  // 강의 이미지 (선택)
 
 	// 커리큘럼 정보
+	@Valid
 	@NotNull(message = "커리큘럼은 필수입니다.")
 	private List<CurriculumInfo> curriculums;
 

--- a/src/main/java/com/example/epari/admin/dto/AdminCourseUpdateRequestDto.java
+++ b/src/main/java/com/example/epari/admin/dto/AdminCourseUpdateRequestDto.java
@@ -1,0 +1,83 @@
+package com.example.epari.admin.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 강의 수정 요청 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminCourseUpdateRequestDto {
+
+	@NotBlank(message = "강의명은 필수입니다.")
+	private String name;
+
+	@NotNull(message = "시작일은 필수입니다.")
+	private LocalDate startDate;
+
+	@NotNull(message = "종료일은 필수입니다.")
+	private LocalDate endDate;
+
+	@NotBlank(message = "강의실은 필수입니다.")
+	private String classroom;
+
+	@NotNull(message = "강사 ID는 필수입니다.")
+	private Long instructorId;
+
+	private MultipartFile courseImage;  // 새로운 강의 이미지 (선택)
+
+	private boolean removeExistingImage;  // 기존 이미지 삭제 여부
+
+	@Valid  // 중첩된 객체의 유효성 검사
+	@NotNull(message = "커리큘럼은 필수입니다.")
+	private List<CurriculumUpdateInfo> curriculums;
+
+	// 날짜 유효성 검증
+	public boolean isValidDateRange() {
+		return !startDate.isAfter(endDate);
+	}
+
+	// 강의 기간 내의 모든 커리큘럼 날짜 유효성 검증
+	public boolean isAllCurriculumDatesValid() {
+		return curriculums.stream()
+				.filter(c -> !c.deleted)  // 삭제 예정인 커리큘럼은 제외
+				.allMatch(c -> c.isDateInRange(startDate, endDate));
+	}
+
+	@Getter
+	@Setter
+	public static class CurriculumUpdateInfo {
+
+		private Long id;  // 기존 커리큘럼의 경우 ID 존재, 신규는 null
+
+		@NotNull(message = "강의 날짜는 필수입니다.")
+		private LocalDate date;
+
+		@NotBlank(message = "강의 주제는 필수입니다.")
+		private String topic;
+
+		private String description;  // 상세 설명 (선택)
+
+		private boolean deleted;  // 삭제 여부
+
+		// 커리큘럼 날짜가 강의 기간 내에 있는지 검증
+		public boolean isDateInRange(LocalDate courseStart, LocalDate courseEnd) {
+			return !date.isBefore(courseStart) && !date.isAfter(courseEnd);
+		}
+
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/dto/CurriculumDetailDto.java
+++ b/src/main/java/com/example/epari/admin/dto/CurriculumDetailDto.java
@@ -1,0 +1,28 @@
+package com.example.epari.admin.dto;
+
+import java.time.LocalDate;
+
+import lombok.Getter;
+
+/**
+ * 커리큘럼 상세 정보 응답 DTO
+ */
+@Getter
+public class CurriculumDetailDto {
+
+	private final Long id;
+
+	private final LocalDate date;
+
+	private final String topic;
+
+	private final String description;
+
+	public CurriculumDetailDto(Long id, LocalDate date, String topic, String description) {
+		this.id = id;
+		this.date = date;
+		this.topic = topic;
+		this.description = description;
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/dto/InstructorInfo.java
+++ b/src/main/java/com/example/epari/admin/dto/InstructorInfo.java
@@ -1,0 +1,20 @@
+package com.example.epari.admin.dto;
+
+import lombok.Getter;
+
+/**
+ * 강사 정보 응답 DTO
+ */
+@Getter
+public class InstructorInfo {
+
+	private final Long id;
+
+	private final String name;
+
+	public InstructorInfo(Long id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+}

--- a/src/main/java/com/example/epari/admin/repository/AdminCourseRepository.java
+++ b/src/main/java/com/example/epari/admin/repository/AdminCourseRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.example.epari.admin.dto.AdminCourseListResponseDto;
 import com.example.epari.admin.dto.CourseSearchResponseDTO;
+import com.example.epari.admin.dto.CurriculumDetailDto;
 import com.example.epari.course.domain.Course;
 
 /**
@@ -67,5 +68,17 @@ public interface AdminCourseRepository extends JpaRepository<Course, Long> {
 			WHERE c.id = :courseId
 			""")
 	Optional<Course> findByIdWithInstructorAndStudents(@Param("courseId") Long courseId);
+
+	/**
+	 * 특정 강의의 커리큘럼을 DTO로 직접 조회하는 쿼리 메서드
+	 */
+	@Query("""
+			SELECT new com.example.epari.admin.dto.CurriculumDetailDto(
+			    cur.id, cur.date, cur.topic, cur.description)
+			FROM Curriculum cur
+			WHERE cur.course.id = :courseId
+			ORDER BY cur.date
+			""")
+	List<CurriculumDetailDto> findCurriculumsByCourseId(@Param("courseId") Long courseId);
 
 }

--- a/src/main/java/com/example/epari/admin/repository/AdminCourseRepository.java
+++ b/src/main/java/com/example/epari/admin/repository/AdminCourseRepository.java
@@ -1,6 +1,7 @@
 package com.example.epari.admin.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -54,5 +55,17 @@ public interface AdminCourseRepository extends JpaRepository<Course, Long> {
 			    ORDER BY c.name ASC
 			""")
 	List<CourseSearchResponseDTO> searchCoursesWithDTO(@Param("keyword") String keyword);
+
+	/**
+	 * 강의 ID로 강의 정보를 조회하며, 강사와 수강생 정보를 함께 페치 조인으로 가져옴
+	 */
+	@Query("""
+			SELECT c
+			FROM Course c
+			JOIN FETCH c.instructor i
+			LEFT JOIN FETCH c.courseStudents cs
+			WHERE c.id = :courseId
+			""")
+	Optional<Course> findByIdWithInstructorAndStudents(@Param("courseId") Long courseId);
 
 }

--- a/src/main/java/com/example/epari/admin/repository/AdminCurriculumRepository.java
+++ b/src/main/java/com/example/epari/admin/repository/AdminCurriculumRepository.java
@@ -1,0 +1,32 @@
+package com.example.epari.admin.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.example.epari.course.domain.Curriculum;
+
+/**
+ * 관리자 - 커리큘럼 정보에 대한 데이터베이스 접근을 담당하는 레포지토리 인터페이스
+ */
+public interface AdminCurriculumRepository extends JpaRepository<Curriculum, Long> {
+
+	/**
+	 * 특정 강의에 속한 커리큘럼들을 ID 리스트를 기준으로 일괄 삭제
+	 */
+	@Query("DELETE FROM Curriculum c WHERE c.course.id = :courseId AND c.id IN :curriculumIds")
+	@Modifying(clearAutomatically = true)
+	void deleteByIdInAndCourseId(
+			@Param("curriculumIds") List<Long> curriculumIds,
+			@Param("courseId") Long courseId
+	);
+
+	/**
+	 * 특정 강의에 속한 모든 커리큘럼 조회
+	 */
+	List<Curriculum> findByCourseId(Long courseId);
+
+}

--- a/src/main/java/com/example/epari/admin/repository/AdminStudentRepository.java
+++ b/src/main/java/com/example/epari/admin/repository/AdminStudentRepository.java
@@ -1,5 +1,7 @@
 package com.example.epari.admin.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -7,40 +9,39 @@ import org.springframework.data.repository.query.Param;
 import com.example.epari.admin.dto.AvailableStudentResponseDTO;
 import com.example.epari.user.domain.Student;
 
-import java.util.List;
-
 /**
  * 관리자 - 학생 정보에 대한 데이터베이스 접근을 담당하는 레포지토리 인터페이스
  */
 public interface AdminStudentRepository extends JpaRepository<Student, Long> {
 
-    /**
-     * 특정 강의에 등록 가능한 학생 목록을 조회
-     * - 해당 강의에 이미 등록된 학생은 제외
-     * - keyword로 이름 또는 이메일 검색 가능
-     * - STUDENT 그룹에 속한 사용자만 조회
-     */
-    @Query("""
-            SELECT new com.example.epari.admin.dto.AvailableStudentResponseDTO(
-                s.id,
-                u.name,
-                u.email
-            )
-            FROM Student s
-            JOIN BaseUser u ON u.id = s.id
-            WHERE s.id NOT IN (
-                SELECT cs.student.id
-                FROM CourseStudent cs
-                WHERE cs.course.id = :courseId
-            )
-            AND (:keyword IS NULL OR :keyword = ''
-                OR LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%')))
-            AND u.role = 'STUDENT'
-            ORDER BY u.name ASC
-            """)
-    List<AvailableStudentResponseDTO> findAvailableStudentsForCourse(
-        @Param("courseId") Long courseId,
-        @Param("keyword") String keyword
-    );
+	/**
+	 * 특정 강의에 등록 가능한 학생 목록을 조회
+	 * - 해당 강의에 이미 등록된 학생은 제외
+	 * - keyword로 이름 또는 이메일 검색 가능
+	 * - STUDENT 그룹에 속한 사용자만 조회
+	 */
+	@Query("""
+			SELECT new com.example.epari.admin.dto.AvailableStudentResponseDTO(
+			    s.id,
+			    u.name,
+			    u.email
+			)
+			FROM Student s
+			JOIN BaseUser u ON u.id = s.id
+			WHERE s.id NOT IN (
+			    SELECT cs.student.id
+			    FROM CourseStudent cs
+			    WHERE cs.course.id = :courseId
+			)
+			AND (:keyword IS NULL OR :keyword = ''
+			    OR LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+			    OR LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%')))
+			AND u.role = 'STUDENT'
+			ORDER BY u.name ASC
+			""")
+	List<AvailableStudentResponseDTO> findAvailableStudentsForCourse(
+			@Param("courseId") Long courseId,
+			@Param("keyword") String keyword
+	);
+
 }

--- a/src/main/java/com/example/epari/admin/service/AdminCourseService.java
+++ b/src/main/java/com/example/epari/admin/service/AdminCourseService.java
@@ -2,6 +2,8 @@ package com.example.epari.admin.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -10,14 +12,17 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.epari.admin.dto.AdminCourseListResponseDto;
 import com.example.epari.admin.dto.AdminCourseRequestDto;
+import com.example.epari.admin.dto.AdminCourseUpdateRequestDto;
 import com.example.epari.admin.dto.CourseSearchResponseDTO;
+import com.example.epari.admin.exception.CourseNotFoundException;
 import com.example.epari.admin.repository.AdminCourseRepository;
+import com.example.epari.admin.repository.AdminCurriculumRepository;
 import com.example.epari.course.domain.Course;
 import com.example.epari.course.domain.Curriculum;
-import com.example.epari.course.repository.CurriculumRepository;
 import com.example.epari.global.common.service.S3FileService;
 import com.example.epari.global.exception.BusinessBaseException;
 import com.example.epari.global.exception.ErrorCode;
+import com.example.epari.global.exception.auth.InstructorNotFoundException;
 import com.example.epari.user.domain.Instructor;
 import com.example.epari.user.repository.InstructorRepository;
 
@@ -39,7 +44,7 @@ public class AdminCourseService {
 
 	private final InstructorRepository instructorRepository;
 
-	private final CurriculumRepository curriculumRepository;
+	private final AdminCurriculumRepository curriculumRepository;
 
 	private final S3FileService s3FileService;
 
@@ -104,6 +109,104 @@ public class AdminCourseService {
 		List<AdminCourseListResponseDto> courses = courseRepository.findAllWithStudentCount();
 		log.info("Found {} courses", courses.size());
 		return courses;
+	}
+
+	/**
+	 * 강의 정보 수정
+	 * 기본 정보, 강사 정보, 커리큘럼, 이미지를 수정합니다.
+	 */
+	@Transactional
+	@CacheEvict(value = "courses", key = "'all'")
+	public void updateCourse(Long courseId, AdminCourseUpdateRequestDto request) {
+		// 1. 강의 및 연관 데이터 조회
+		Course course = courseRepository.findByIdWithInstructorAndStudents(courseId)
+				.orElseThrow(CourseNotFoundException::new);
+
+		// 2. 강사 조회
+		Instructor instructor = instructorRepository.findById(request.getInstructorId())
+				.orElseThrow(InstructorNotFoundException::new);
+
+		// 3. 이미지 처리
+		updateCourseImage(course, request);
+
+		// 4. 강의 기본 정보 수정
+		course.updateCourse(
+				request.getName(),
+				request.getStartDate(),
+				request.getEndDate(),
+				request.getClassroom(),
+				instructor
+		);
+
+		// 5. 커리큘럼 수정
+		updateCourseCurriculums(course, request.getCurriculums());
+	}
+
+	/**
+	 * 강의 이미지 수정
+	 */
+	private void updateCourseImage(Course course, AdminCourseUpdateRequestDto request) {
+		// 기존 이미지 삭제 요청이 있는 경우
+		if (request.isRemoveExistingImage() && course.getImageUrl() != null) {
+			s3FileService.deleteFile(course.getImageUrl());
+			course.updateCourseImage(null);
+		}
+
+		// 새로운 이미지가 있는 경우
+		if (request.getCourseImage() != null && !request.getCourseImage().isEmpty()) {
+			// 기존 이미지가 있다면 삭제
+			if (course.getImageUrl() != null) {
+				s3FileService.deleteFile(course.getImageUrl());
+			}
+			String imageUrl = s3FileService.uploadFile(COURSE_IMAGE_DIRECTORY, request.getCourseImage());
+			course.updateCourseImage(imageUrl);
+		}
+	}
+
+	/**
+	 * 커리큘럼 수정
+	 */
+	private void updateCourseCurriculums(Course course,
+			List<AdminCourseUpdateRequestDto.CurriculumUpdateInfo> curriculumInfos) {
+		Map<Long, Curriculum> existingCurriculumsMap = curriculumRepository.findByCourseId(course.getId())
+				.stream()
+				.collect(Collectors.toMap(Curriculum::getId, c -> c));
+
+		List<Long> curriculumsToDelete = new ArrayList<>();
+		List<Curriculum> curriculumsToAdd = new ArrayList<>();
+
+		for (AdminCourseUpdateRequestDto.CurriculumUpdateInfo info : curriculumInfos) {
+			if (info.isDeleted() && info.getId() != null) {
+				// 삭제할 커리큘럼
+				curriculumsToDelete.add(info.getId());
+			} else if (info.getId() == null) {
+				// 새로운 커리큘럼
+				curriculumsToAdd.add(Curriculum.builder()
+						.date(info.getDate())
+						.topic(info.getTopic())
+						.description(info.getDescription())
+						.course(course)
+						.build());
+			} else {
+				// 기존 커리큘럼 수정
+				Curriculum existingCurriculum = existingCurriculumsMap.get(info.getId());
+				if (existingCurriculum != null) {
+					existingCurriculum.update(  // Curriculum 엔티티에 update 메서드 추가 필요
+							info.getDate(),
+							info.getTopic(),
+							info.getDescription()
+					);
+				}
+			}
+		}
+
+		// 커리큘럼 삭제 및 추가 처리
+		if (!curriculumsToDelete.isEmpty()) {
+			curriculumRepository.deleteByIdInAndCourseId(curriculumsToDelete, course.getId());
+		}
+		if (!curriculumsToAdd.isEmpty()) {
+			curriculumRepository.saveAll(curriculumsToAdd);
+		}
 	}
 
 }

--- a/src/main/java/com/example/epari/course/domain/Course.java
+++ b/src/main/java/com/example/epari/course/domain/Course.java
@@ -1,6 +1,7 @@
 package com.example.epari.course.domain;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import com.example.epari.global.common.base.BaseTimeEntity;
 import com.example.epari.user.domain.Instructor;
@@ -18,8 +19,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 /**
  * 강의 정보를 관리하는 Entity 클래스
@@ -50,7 +49,7 @@ public class Course extends BaseTimeEntity {
 	private Instructor instructor;
 
 	@OneToMany(mappedBy = "course")
-    private List<CourseStudent> courseStudents;
+	private List<CourseStudent> courseStudents;
 
 	@Builder
 	private Course(String name, LocalDate startDate, LocalDate endDate, String classroom, Instructor instructor) {
@@ -79,6 +78,16 @@ public class Course extends BaseTimeEntity {
 		this.startDate = startDate;
 		this.endDate = endDate;
 		this.classroom = classroom;
+	}
+
+	// 강의 수정 메서드
+	public void updateCourse(String name, LocalDate startDate, LocalDate endDate, String classroom,
+			Instructor instructor) {
+		this.name = name;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.classroom = classroom;
+		this.instructor = instructor;
 	}
 
 	public void updateCourseImage(String imageUrl) {

--- a/src/main/java/com/example/epari/course/domain/Curriculum.java
+++ b/src/main/java/com/example/epari/course/domain/Curriculum.java
@@ -49,4 +49,11 @@ public class Curriculum {
 		this.course = course;
 	}
 
+	// 커리큘럼 수정 메서드
+	public void update(LocalDate date, String topic, String description) {
+		this.date = date;
+		this.topic = topic;
+		this.description = description;
+	}
+
 }


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- ex) Closes #이슈번호 -->
- Closes #139 

## 변경 사항
<!-- 이 PR에서 변경된 주요 내용을 설명해주세요.
     변경사항이 여러 개일 경우, 주요 내용과 하위 항목을 구분하여 작성해주세요. -->
1. 강의 상세 정보 조회 기능 구현
   - AdminCourseDetailResponseDto, CurriculumDetailDto, InstructorInfo DTO 구현
   - AdminCourseRepository에 페치 조인을 활용한 조회 메서드 구현
   - 강의 상세 정보 조회 비즈니스 로직 구현
   - 상세 정보 조회 API 엔드포인트 구현

2. 강의 수정 기능 구현
   - AdminCourseRequestDto 구현 및 유효성 검사 적용
   - AdminCurriculumRepository 구현 및 커리큘럼 관련 쿼리 메서드 구현
   - 강의 정보, 이미지, 커리큘럼 수정 메서드 구현
   - 수정 API 엔드포인트 구현

## 스크린샷
<!-- (선택) 주요 변경사항(기능 구현 화면, 테스트 결과 등)에 대한 이미지를 삽입해주세요. -->
|기능|스크린샷|
|---|---|
|강의 상세 정보 조회|![image](https://github.com/user-attachments/assets/d9ce0285-34d6-485f-85ce-360427c29654)|
|강의 수정|![image](https://github.com/user-attachments/assets/8abb3f5d-65d3-4d17-8a2f-c0940dc7e80a)|

수정의 경우 Postman 사용에 어려움이 있어 개발자 도구의 Network 탭으로 스크린샷을 대체하였습니다.
양해 부탁드립니다.

## 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항들입니다. -->
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 모든 테스트를 통과하였습니까?
- [x] 관련 문서를 업데이트하였습니까?

## 공유사항
<!-- 리뷰어에게 전달할 추가 정보가 있다면 여기에 적어주세요. -->
- 강의 조회 시 N+1 문제를 방지하기 위해 페치 조인을 사용했습니다.

## 추후 업무
<!-- 추후 진행될 과제에 대해 적어주세요. -->