### PR TITLE
[FEAT] 강사/학생 정보에 프로필 이미지 URL 추가 및 관련 기능 구현

### DIFF
--- a/src/main/java/com/example/epari/course/dto/attendance/AttendanceStatResponseDto.java
+++ b/src/main/java/com/example/epari/course/dto/attendance/AttendanceStatResponseDto.java
@@ -27,11 +27,15 @@ public class AttendanceStatResponseDto {
 
 		private String email;
 
+		private String profileFileUrl;
+
 		public static StudentInfo from(Student student) {
 			return StudentInfo.builder()
 					.id(student.getId())
 					.name(student.getName())
 					.email(student.getEmail())
+					.profileFileUrl(student.getProfileImage() != null ?
+							student.getProfileImage().getFileUrl() : null)  // 프로필 이미지 URL 추가
 					.build();
 		}
 

--- a/src/main/java/com/example/epari/course/dto/course/CourseResponseDto.java
+++ b/src/main/java/com/example/epari/course/dto/course/CourseResponseDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 import com.example.epari.course.domain.Course;
 import com.example.epari.user.domain.Instructor;
+import com.example.epari.user.domain.ProfileImage;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -33,18 +34,24 @@ public class CourseResponseDto {
 	@Getter
 	@Builder
 	public static class InstructorInfo {
+
 		private Long id;
+
 		private String name;
+
 		private String email;
-		private String phoneNumber;
+
+		private ProfileImage profileImage;
 
 		public static InstructorInfo from(Instructor instructor) {
 			return InstructorInfo.builder()
 					.id(instructor.getId())
 					.name(instructor.getName())
 					.email(instructor.getEmail())
+					.profileImage(instructor.getProfileImage())
 					.build();
 		}
+
 	}
 
 	public static CourseResponseDto from(Course course) {

--- a/src/main/java/com/example/epari/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/epari/course/repository/CourseRepository.java
@@ -1,6 +1,7 @@
 package com.example.epari.course.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,6 +19,8 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 	 * 학생 id를 받아 강의 id 와 학생 id 일치로 조회 강의 조회
 	 */
 	@Query("SELECT c FROM Course c "
+			+ "INNER JOIN FETCH c.instructor i "
+			+ "LEFT JOIN FETCH i.profileImage "
 			+ "INNER JOIN CourseStudent cs ON c.id = cs.course.id "
 			+ "WHERE cs.student.id = :studentId")
 	List<Course> findAllByStudentId(@Param("studentId") Long studentId);
@@ -26,6 +29,8 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 	 * 강사 id를 받아 강의 테이블에서 일치하는지 확인 강의 조회
 	 */
 	@Query("SELECT c FROM Course c "
+			+ "INNER JOIN FETCH c.instructor i "
+			+ "LEFT JOIN FETCH i.profileImage "
 			+ "WHERE c.instructor.id = :instructorId")
 	List<Course> findAllByInstructorId(@Param("instructorId") Long instructorId);
 
@@ -59,5 +64,10 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
 	boolean existsByCourseIdAndStudentEmail(
 			@Param("courseId") Long courseId,
 			@Param("studentEmail") String studentEmail);
+
+	@Query("SELECT c FROM Course c " +
+			"INNER JOIN FETCH c.instructor i " +
+			"WHERE c.id = :courseId")
+	Optional<Course> findByIdWithInstructor(@Param("courseId") Long courseId);
 
 }

--- a/src/main/java/com/example/epari/course/repository/CourseStudentRepository.java
+++ b/src/main/java/com/example/epari/course/repository/CourseStudentRepository.java
@@ -16,7 +16,8 @@ public interface CourseStudentRepository extends JpaRepository<CourseStudent, Lo
 	@Query("""
 			SELECT ls
 			FROM CourseStudent ls
-			JOIN FETCH ls.student
+			JOIN FETCH ls.student s
+			LEFT JOIN FETCH s.profileImage
 			WHERE ls.course.id = :courseId
 			""")
 	List<CourseStudent> findAllCourseStudentsByCourseId(

--- a/src/main/java/com/example/epari/course/service/CourseService.java
+++ b/src/main/java/com/example/epari/course/service/CourseService.java
@@ -62,7 +62,7 @@ public class CourseService {
 	 * 강의 정보를 조회합니다.
 	 */
 	public CourseResponseDto getCourse(Long courseId) {
-		Course course = courseRepository.findById(courseId)
+		Course course = courseRepository.findByIdWithInstructor(courseId)
 				.orElseThrow(CourseNotFoundException::new);
 		return CourseResponseDto.from(course);
 	}

--- a/src/main/java/com/example/epari/global/auth/controller/AuthController.java
+++ b/src/main/java/com/example/epari/global/auth/controller/AuthController.java
@@ -90,4 +90,11 @@ public class AuthController {
 		return ResponseEntity.ok().body(new SuccessResponseDto("승인 대기 그룹에 추가되었습니다."));
 	}
 
+	@PostMapping("/google-profile")
+	public ResponseEntity<Void> updateGoogleProfileImage(
+			@RequestBody Map<String, String> payload) {
+		authService.updateGoogleProfileImage(payload.get("email"), payload.get("imageUrl"));
+		return ResponseEntity.ok().build();
+	}
+
 }

--- a/src/main/java/com/example/epari/global/init/InitDataLoader.java
+++ b/src/main/java/com/example/epari/global/init/InitDataLoader.java
@@ -155,6 +155,28 @@ public class InitDataLoader implements ApplicationRunner {
 			);
 			students.add(student);
 		}
+
+		// 첫 번째 학생 추가
+		Student student1 = Student.createStudent(
+				"wlsgml0053@naver.com",
+				"일반진희"
+		);
+		students.add(student1);
+
+		// 두 번째 학생 추가 (Google 계정)
+		Student student2 = Student.createStudent(
+				"wlsgml0053@gmail.com",
+				"구글진희"
+		);
+		students.add(student2);
+
+		// 세 번째 학생 추가 (Google 계정)
+		Student student3 = Student.createStudent(
+				"limiary27@gmail.com",
+				"구글진희2"
+		);
+		students.add(student3);
+
 		return studentRepository.saveAll(students);
 	}
 
@@ -406,7 +428,7 @@ public class InitDataLoader implements ApplicationRunner {
 
 	private boolean isWeekend(LocalDate date) {
 		return date.getDayOfWeek() == java.time.DayOfWeek.SATURDAY
-			   || date.getDayOfWeek() == java.time.DayOfWeek.SUNDAY;
+				|| date.getDayOfWeek() == java.time.DayOfWeek.SUNDAY;
 	}
 
 	private static class CurriculumInfo {

--- a/src/main/java/com/example/epari/user/service/UserProfileService.java
+++ b/src/main/java/com/example/epari/user/service/UserProfileService.java
@@ -5,7 +5,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.example.epari.global.common.base.BaseUser;
+import com.example.epari.global.common.repository.BaseUserRepository;
 import com.example.epari.global.common.service.S3FileService;
+import com.example.epari.user.domain.ProfileImage;
 
 import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
@@ -24,6 +27,8 @@ public class UserProfileService {
 
 	private final AsyncTaskExecutor asyncTaskExecutor;
 
+	private final BaseUserRepository userRepository;
+
 	@Transactional
 	public String updateProfileImage(String username, MultipartFile file, String accessToken) {
 		try {
@@ -36,7 +41,15 @@ public class UserProfileService {
 			// 3. Cognito 사용자 속성 업데이트
 			updateCognitoAttribute(accessToken, newImageUrl);
 
-			// 4. 이전 이미지 비동기 삭제 (있는 경우)
+			// 4. DB 업데이트 - URL만 저장
+			BaseUser user = userRepository.findByEmail(username)
+					.orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+			ProfileImage profileImage = ProfileImage.of(
+					null, null, newImageUrl, null
+			);
+			user.updateProfileImage(profileImage);
+
+			// 5. 이전 이미지 비동기 삭제
 			if (currentImageUrl != null && !currentImageUrl.isEmpty()) {
 				asyncTaskExecutor.execute(() -> {
 					try {
@@ -48,7 +61,6 @@ public class UserProfileService {
 			}
 
 			return newImageUrl;
-
 		} catch (Exception e) {
 			throw new RuntimeException("프로필 이미지 업데이트 중 오류가 발생했습니다: " + e.getMessage(), e);
 		}
@@ -94,7 +106,12 @@ public class UserProfileService {
 			// 1. Cognito 속성 먼저 업데이트
 			updateCognitoAttribute(accessToken, "");
 
-			// 2. S3 이미지 비동기 삭제
+			// 2. DB 업데이트
+			BaseUser user = userRepository.findByEmail(username)
+					.orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+			user.updateProfileImage(null);
+
+			// 3. S3 이미지 비동기 삭제
 			asyncTaskExecutor.execute(() -> {
 				try {
 					s3FileService.deleteFile(currentImageUrl);


### PR DESCRIPTION
## 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요. -->
<!-- ex) Closes #이슈번호 -->
- Closes #133 

## 변경 사항
<!-- 이 PR에서 변경된 주요 내용을 설명해주세요.
     변경사항이 여러 개일 경우, 주요 내용과 하위 항목을 구분하여 작성해주세요. -->
<!-- ex) 1. 000 엔티티 구현 -->
<!--        - 000 메서드 구현 -->
1. 강사/학생 정보에 프로필 이미지 URL 추가  
   - InstructorInfo DTO에서 phoneNumber 필드 제거  
   - InstructorInfo DTO에 ProfileImage 필드 추가 및 매핑 로직 구현  
   - StudentInfo DTO에 profileFileUrl 필드 추가  
   - Student 엔티티의 프로필 이미지 정보를 URL로 변환하는 로직 구현  

2. 강의 조회 시 N+1 문제 해결을 위한 쿼리 최적화  
   - 학생/강사 ID로 강의를 조회할 때, instructor와 profileImage를 FETCH JOIN으로 변경  
   - 단일 강의 조회를 위한 `findByIdWithInstructor` 메소드 추가  

3. 수강생 목록 조회 시 프로필 이미지 정보 포함  
   - 수강생 목록 조회 쿼리에 `profileImage` 테이블 LEFT JOIN FETCH 추가  

4. 프로필 이미지 DB 저장 및 삭제 기능 구현  
   - 사용자 조회 기능 추가 및 프로필 이미지 업로드 시 DB에 저장  
   - 프로필 이미지 삭제 시 DB에서 정보 제거  

5. 구글 계정 사용자의 프로필 사진 URL 저장 및 연동 기능 구현  
   - 구글 OAuth로 받은 프로필 이미지 URL을 업데이트하는 엔드포인트 구현  
  
## 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 사항들입니다. -->
- [ ] 코드 컨벤션을 준수하였습니까?
- [ ] 모든 테스트를 통과하였습니까?
- [ ] 관련 문서를 업데이트하였습니까?

## 추후 업무
<!-- 추후 진행될 과제에 대해 적어주세요. -->
<!-- ex) [ ] 000 기능 구현 -->
- [ ] 구글 로그인 관련 오류 해결